### PR TITLE
core v2: sign up events

### DIFF
--- a/core/src/node/commit_log.rs
+++ b/core/src/node/commit_log.rs
@@ -1,11 +1,10 @@
-use std::ops::Deref;
 use std::rc::Rc;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use crate::crypto;
 
 use crate::models::{AppCommandType, Base64EncodedText, KvKey, KvLogEvent, KvValueType, UserSignature, VaultDoc};
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct MetaDb {
     pub meta_store: MetaStore,
 }
@@ -14,6 +13,8 @@ pub struct DbLog {
     pub events: Vec<KvLogEvent>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct MetaStore {
     pub server_pk: Option<Base64EncodedText>,
     pub vault: Option<VaultDoc>,
@@ -34,6 +35,22 @@ pub enum LogCommandError {
         #[from]
         source: serde_json::Error,
     },
+}
+
+fn accept_sign_up_request(vault: &VaultDoc) -> KvLogEvent {
+    KvLogEvent {
+        key: Box::from(generate_key()),
+        cmd_type: AppCommandType::Update,
+        val_type: KvValueType::Vault,
+        value: Some(serde_json::to_string(&vault).unwrap()),
+    }
+}
+
+fn generate_key() -> KvKey {
+    KvKey {
+        store: "commit_log".to_string(),
+        id: crypto::utils::rand_uuid_b64_url_enc()
+    }
 }
 
 fn accept(request: KvLogEvent, meta_db: MetaDb) -> KvLogEvent {
@@ -71,7 +88,6 @@ fn accept(request: KvLogEvent, meta_db: MetaDb) -> KvLogEvent {
         let members = &mut vault.signatures;
         members.push(user_sig);
 
-        //create a log event
         KvLogEvent {
             key: Box::from(KvKey { store: request.key.store, id: crypto::utils::rand_uuid_b64_url_enc() }),
             cmd_type: AppCommandType::Update,
@@ -103,7 +119,28 @@ fn transform(commit_log: Rc<Vec<KvLogEvent>>) -> Result<MetaDb, LogCommandError>
                 }
             }
             _ => {
-                panic!("yay")
+                match event.cmd_type {
+                    AppCommandType::Update => {
+                        match event.value.as_ref() {
+                            None => {
+
+                            }
+                            Some(vault_str) => {
+                                let vault: VaultDoc = serde_json::from_str(vault_str.as_str()).unwrap();
+                                meta_db.meta_store.vault = Some(vault);
+                            }
+                        }
+                    }
+                    AppCommandType::Genesis => {
+                        todo!("Not implemented yet");
+                    }
+                    AppCommandType::SignUp => {
+                        println!("found sign up request");
+                    }
+                    AppCommandType::JoinCluster => {
+                        todo!("Not implemented yet");
+                    }
+                }
             }
         }
     }
@@ -113,25 +150,39 @@ fn transform(commit_log: Rc<Vec<KvLogEvent>>) -> Result<MetaDb, LogCommandError>
 
 fn generate_genesis_event(value: &Base64EncodedText) -> KvLogEvent {
     KvLogEvent {
-        key: Box::from(KvKey {
-            store: "commit_log".to_string(),
-            id: crypto::utils::rand_uuid_b64_url_enc(),
-        }),
+        key: Box::from(generate_key()),
         cmd_type: AppCommandType::Genesis,
         val_type: KvValueType::DsaPublicKey,
         value: Some(serde_json::to_string(&value).unwrap()),
     }
 }
 
+fn sign_up_event(user_sig: &UserSignature) -> KvLogEvent {
+    KvLogEvent {
+        key: Box::from(generate_key()),
+        cmd_type: AppCommandType::SignUp,
+        val_type: KvValueType::UserSignature,
+        value: Some(serde_json::to_string(user_sig).unwrap()),
+    }
+}
+
+fn join_cluster_event(user_sig: &UserSignature) -> KvLogEvent {
+    KvLogEvent {
+        key: Box::from(generate_key()),
+        cmd_type: AppCommandType::JoinCluster,
+        val_type: KvValueType::UserSignature,
+        value: Some(serde_json::to_string(user_sig).unwrap()),
+    }
+}
+
 #[cfg(test)]
 pub mod test {
     use std::rc::Rc;
-    use crate::crypto;
 
     use crate::crypto::key_pair::KeyPair;
     use crate::crypto::keys::KeyManager;
-    use crate::models::{DeviceInfo, KvKey, KvLogEvent, KvValueType, UserCredentials, VaultDoc};
-    use crate::node::commit_log::{accept, AppCommandType, generate_genesis_event, LogCommandError, MetaDb, MetaStore, transform};
+    use crate::models::{DeviceInfo, VaultDoc};
+    use crate::node::commit_log::{accept, accept_sign_up_request, generate_genesis_event, join_cluster_event, LogCommandError, sign_up_event, transform};
 
     //genesis:
     // - generate keys on server
@@ -150,64 +201,31 @@ pub mod test {
     }
 
     #[test]
-    fn test() {
+    fn sign_up() -> Result<(), LogCommandError> {
         let server_km = KeyManager::generate();
         let genesis_event = generate_genesis_event(&server_km.dsa.public_key());
 
         let vault_name = "test".to_string();
 
-        //server provides to client a commit log that contains only one record (genesis), which contains server's pk
-        let mut command_log = vec![genesis_event];
-
         let a_s_box = KeyManager::generate_security_box(vault_name.clone());
         let a_device = DeviceInfo::new("a".to_string(), "a".to_string());
         let a_user_sig = a_s_box.get_user_sig(&a_device);
-        let a_creds = UserCredentials::new(a_s_box, a_user_sig.clone());
 
-        let sign_up_event = KvLogEvent {
-            key: Box::from(KvKey {
-                store: "commit_log".to_string(),
-                id: crypto::utils::rand_uuid_b64_url_enc(),
-            }),
-            cmd_type: AppCommandType::SignUp,
-            val_type: KvValueType::UserSignature,
-            value: Some(serde_json::to_string(&a_user_sig).unwrap()),
+        let sign_up_event = sign_up_event(&a_user_sig);
+
+        let vault = VaultDoc {
+            vault_name,
+            signatures: vec![a_user_sig],
+            pending_joins: vec![],
+            declined_joins: vec![],
         };
+        let sing_up_accept = accept_sign_up_request(&vault);
 
-        command_log.push(sign_up_event);
+        let commit_log = vec![genesis_event, sign_up_event, sing_up_accept];
+        let meta_db = transform(Rc::new(commit_log))?;
 
-        let b_s_box = KeyManager::generate_security_box(vault_name.clone());
-        let b_device = DeviceInfo::new("b".to_string(), "b".to_string());
-        let b_user_sig = b_s_box.get_user_sig(&b_device);
+        assert_eq!(vault, meta_db.meta_store.vault.unwrap());
 
-        let join_command = KvLogEvent {
-            key: Box::from(KvKey {
-                store: "commit_log".to_string(),
-                id: crypto::utils::rand_uuid_b64_url_enc(),
-            }),
-            cmd_type: AppCommandType::JoinCluster,
-            val_type: KvValueType::UserSignature,
-            value: Some(serde_json::to_string(&b_user_sig).unwrap()),
-        };
-
-        let meta_db = MetaDb {
-            meta_store: MetaStore {
-                server_pk: None,
-                vault: Some(VaultDoc {
-                    vault_name,
-                    signatures: vec![a_user_sig],
-                    pending_joins: vec![],
-                    declined_joins: vec![],
-                }),
-            },
-        };
-
-        let join_event = accept(join_command, meta_db);
-        command_log.push(join_event);
-
-        for command in command_log {
-            println!("{}", serde_json::to_string(&command).unwrap());
-            println!("")
-        }
+        Ok(())
     }
 }


### PR DESCRIPTION
Implement sign_up functionality on the commit log level: user can register a vault by sending a sign_up event 