### PR TITLE
v2: implement PersistentObjectNavigator

### DIFF
--- a/core/src/crypto/key_pair.rs
+++ b/core/src/crypto/key_pair.rs
@@ -9,7 +9,7 @@ use rand::rngs::OsRng as RandOsRng;
 use rand::RngCore;
 
 use crate::errors::CoreError;
-use crate::models::{AeadAuthData, AeadCipherText, AeadPlainText, Base64EncodedText, CommunicationChannel};
+use crate::node::common::model::crypto::{AeadAuthData, AeadCipherText, AeadPlainText, Base64Text, CommunicationChannel};
 use crate::CoreResult;
 
 pub type CryptoBoxPublicKey = crypto_box::PublicKey;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -23,7 +23,6 @@ use crate::secret::shared_secret::{PlainText, SharedSecret, SharedSecretEncrypti
 
 pub mod crypto;
 pub mod errors;
-pub mod models;
 pub mod node;
 pub mod sdk;
 pub mod secret;

--- a/core/src/node/common/model.rs
+++ b/core/src/node/common/model.rs
@@ -217,7 +217,7 @@ pub mod vault {
     }
 }
 
-mod crypto {
+pub mod crypto {
     use crate::crypto::encoding::base64::Base64Text;
     use crate::node::common::model::user::UserData;
 

--- a/core/src/node/db/events/generic_log_event.rs
+++ b/core/src/node/db/events/generic_log_event.rs
@@ -72,7 +72,6 @@ impl KeyExtractor for GenericKvLogEvent {
         match self {
             GenericKvLogEvent::GlobalIndex(obj) => obj.key(),
             GenericKvLogEvent::Vault(obj) => obj.key(),
-            GenericKvLogEvent::MetaPass(obj) => obj.key(),
             GenericKvLogEvent::SharedSecret(obj) => obj.key(),
             GenericKvLogEvent::Credentials(obj) => obj.key(),
             GenericKvLogEvent::DbTail(obj) => obj.key(),

--- a/core/src/node/db/events/global_index.rs
+++ b/core/src/node/db/events/global_index.rs
@@ -67,7 +67,7 @@ impl UnitEventWithEmptyValue for GlobalIndexObject {
 }
 
 impl GlobalIndexObject {
-    pub fn genesis(server_pk: &PublicKeyRecord) -> Self {
+    pub fn genesis(server_pk: PublicKeyRecord) -> Self {
         GlobalIndexObject::Genesis {
             event: KvLogEvent::global_index_genesis(server_pk),
         }

--- a/core/src/node/db/events/kv_log_event.rs
+++ b/core/src/node/db/events/kv_log_event.rs
@@ -19,18 +19,18 @@ pub struct KvEvent<T> {
 }
 
 impl KvLogEvent<GenesisId, PublicKeyRecord> {
-    pub fn genesis(obj_desc: ObjectDescriptor, server_pk: &PublicKeyRecord) -> KvLogEvent<GenesisId, PublicKeyRecord> {
+    pub fn genesis(obj_desc: ObjectDescriptor, server_pk: PublicKeyRecord) -> KvLogEvent<GenesisId, PublicKeyRecord> {
         KvLogEvent {
             key: KvKey::genesis(obj_desc),
-            value: server_pk.clone(),
+            value: server_pk,
         }
     }
 
     pub fn vault_unit(user_sig: UserDataCandidate) -> KvLogEvent<UnitId, UserDataCandidate> {
-        let obj_desc = ObjectDescriptor::vault(user_sig.data.vault_name);
+        let obj_desc = ObjectDescriptor::vault(user_sig.data.vault_name.clone());
         KvLogEvent {
             key: KvKey::unit(obj_desc),
-            value: user_sig.clone(),
+            value: user_sig,
         }
     }
 
@@ -41,7 +41,7 @@ impl KvLogEvent<GenesisId, PublicKeyRecord> {
         }
     }
 
-    pub fn global_index_genesis(server_pk: &PublicKeyRecord) -> KvLogEvent<GenesisId, PublicKeyRecord> {
+    pub fn global_index_genesis(server_pk: PublicKeyRecord) -> KvLogEvent<GenesisId, PublicKeyRecord> {
         Self::genesis(ObjectDescriptor::GlobalIndex(GlobalIndexDescriptor::Index), server_pk)
     }
 }

--- a/core/src/node/db/generic_db.rs
+++ b/core/src/node/db/generic_db.rs
@@ -11,6 +11,7 @@ pub trait SaveCommand {
 #[async_trait(? Send)]
 pub trait FindOneQuery {
     async fn find_one(&self, key: ObjectId) -> anyhow::Result<Option<GenericKvLogEvent>>;
+    async fn get_key(&self, key: ObjectId) -> anyhow::Result<Option<ObjectId>>;
 }
 
 #[async_trait(? Send)]

--- a/core/src/node/db/mod.rs
+++ b/core/src/node/db/mod.rs
@@ -4,4 +4,3 @@ pub mod generic_db;
 pub mod in_mem_db;
 pub mod read_db;
 pub mod objects;
-pub mod collections;

--- a/core/src/node/db/objects/mod.rs
+++ b/core/src/node/db/objects/mod.rs
@@ -1,1 +1,2 @@
 pub mod persistent_object;
+pub mod persistent_object_navigator;

--- a/core/src/node/db/objects/persistent_object.rs
+++ b/core/src/node/db/objects/persistent_object.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use tracing::{debug, info, instrument, Instrument};
 
-use crate::node::app::credentials_repo::{CredentialsRepo};
+use crate::node::app::credentials_repo::CredentialsRepo;
 use crate::node::common::model::device::{DeviceCredentials, DeviceName};
 use crate::node::common::model::user::{UserCredentials, UserDataCandidate};
 use crate::node::common::model::vault::VaultName;
@@ -17,6 +17,7 @@ use crate::node::db::events::object_descriptor::ObjectDescriptor;
 use crate::node::db::events::object_id::{Next, ObjectId, UnitId};
 use crate::node::db::events::vault_event::VaultObject;
 use crate::node::db::generic_db::KvLogEventRepo;
+use crate::node::db::objects::persistent_object_navigator::PersistentObjectNavigator;
 
 pub struct PersistentObject<Repo: KvLogEventRepo> {
     pub repo: Arc<Repo>,
@@ -89,6 +90,11 @@ impl<Repo: KvLogEventRepo> PersistentObject<Repo> {
     pub async fn find_tail_id_by_obj_desc(&self, obj_desc: ObjectDescriptor) -> anyhow::Result<Option<ObjectId>> {
         let unit_id = ObjectId::unit(obj_desc);
         self.find_tail_id(unit_id).await
+    }
+
+    #[instrument(skip_all)]
+    pub async fn navigator(&self, obj_id: ObjectId) -> PersistentObjectNavigator<Repo> {
+        PersistentObjectNavigator::build(self.repo.clone(), obj_id).await
     }
 
     #[instrument(skip_all)]

--- a/core/src/node/db/objects/persistent_object_navigator.rs
+++ b/core/src/node/db/objects/persistent_object_navigator.rs
@@ -1,0 +1,71 @@
+use std::sync::Arc;
+
+use crate::node::db::events::object_id::{Next, ObjectId};
+use crate::node::db::generic_db::{FindOneQuery, KvLogEventRepo};
+
+pub struct PersistentObjectNavigator<Repo: KvLogEventRepo> {
+    repo: Arc<Repo>,
+    obj_id: ObjectId,
+}
+
+impl<Repo: KvLogEventRepo> PersistentObjectNavigator<Repo> {
+    pub async fn build(repo: Arc<Repo>, obj_id: ObjectId) -> PersistentObjectNavigator<Repo> {
+        PersistentObjectNavigator {
+            repo: repo.clone(),
+            obj_id,
+        }
+    }
+
+    pub async fn next(&mut self) -> anyhow::Result<Option<ObjectId>> {
+        let maybe_key = self.repo.get_key(self.obj_id.clone()).await?;
+
+        if let Some(obj_id) = maybe_key {
+            self.obj_id = obj_id.next();
+            Ok(Some(obj_id.clone()))
+        } else {
+            Ok(None)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use crate::crypto::keys::{KeyManager, OpenBox};
+    use crate::node::db::events::common::PublicKeyRecord;
+    use crate::node::db::events::generic_log_event::{ObjIdExtractor, ToGenericEvent, UnitEventWithEmptyValue};
+    use crate::node::db::events::global_index::GlobalIndexObject;
+    use crate::node::db::events::object_id::{GenesisId, ObjectId};
+    use crate::node::db::generic_db::SaveCommand;
+    use crate::node::db::in_mem_db::InMemKvLogEventRepo;
+    use crate::node::db::objects::persistent_object_navigator::PersistentObjectNavigator;
+
+    #[tokio::test]
+    async fn test_iterator() -> anyhow::Result<()> {
+        let repo = Arc::new(InMemKvLogEventRepo::default());
+
+        let server_pk = {
+            let secret_box = KeyManager::generate_secret_box();
+            let open_box = OpenBox::from(&secret_box);
+            PublicKeyRecord::from(open_box.dsa_pk)
+        };
+
+        let unit_event = GlobalIndexObject::unit().to_generic();
+        let genesis_event = GlobalIndexObject::genesis(server_pk).to_generic();
+
+        repo.save(unit_event).await?;
+        repo.save(genesis_event).await?;
+
+        let mut navigator = PersistentObjectNavigator::build(repo, unit_event.obj_id()).await;
+
+        while let Ok(Some(curr_id)) = navigator.next().await {
+            // since there is only one more event in the db (genesis), we expect to see only the genesis event here
+            let ObjectId::Genesis(GenesisId { .. }) = curr_id else {
+                panic!("Key has to be: GenesisId")
+            };
+        }
+
+        Ok(())
+    }
+}

--- a/wasm/src/wasm_repo.rs
+++ b/wasm/src/wasm_repo.rs
@@ -1,17 +1,17 @@
 use anyhow::anyhow;
 use async_trait::async_trait;
-use indexed_db_futures::prelude::*;
 use indexed_db_futures::IdbDatabase;
+use indexed_db_futures::prelude::*;
 use js_sys::Object;
+use tracing::{Instrument, instrument};
+use wasm_bindgen::JsValue;
+use web_sys::IdbTransactionMode;
+
 use meta_secret_core::node::db::events::generic_log_event::{GenericKvLogEvent, ObjIdExtractor};
 use meta_secret_core::node::db::events::object_id::ObjectId;
 use meta_secret_core::node::db::generic_db::{
     CommitLogDbConfig, DeleteCommand, FindOneQuery, KvLogEventRepo, SaveCommand,
 };
-use tracing::{Instrument, instrument};
-use wasm_bindgen::JsValue;
-use web_sys::IdbTransactionMode;
-use tracing::Level;
 
 pub struct WasmRepo {
     pub db_name: String,
@@ -48,10 +48,16 @@ impl WasmRepo {
             store_name: String::from("commit_log"),
         }
     }
+
+    async fn get_store(&self) -> Result<IdbObjectStore, Error> {
+        let db = open_db(self.db_name.as_str()).in_current_span().await;
+        let tx = db.transaction_on_one(self.store_name.as_str())?;
+        let store = tx.object_store(self.store_name.as_str())?;
+        Ok(store)
+    }
 }
 
 impl WasmRepo {
-
     #[instrument(level = Level::DEBUG)]
     pub async fn delete_db(&self) {
         let db = open_db(self.db_name.as_str()).in_current_span().await;
@@ -61,7 +67,6 @@ impl WasmRepo {
 
 #[async_trait(? Send)]
 impl SaveCommand for WasmRepo {
-
     #[instrument(level = Level::DEBUG)]
     async fn save(&self, event: GenericKvLogEvent) -> anyhow::Result<ObjectId> {
         let event_js: JsValue = serde_wasm_bindgen::to_value(&event)?;
@@ -87,38 +92,56 @@ impl SaveCommand for WasmRepo {
 
 #[async_trait]
 impl FindOneQuery for WasmRepo {
-
     #[instrument(level = Level::DEBUG)]
     async fn find_one(&self, key: ObjectId) -> anyhow::Result<Option<GenericKvLogEvent>> {
-        let db = open_db(self.db_name.as_str()).in_current_span().await;
-        let tx = db.transaction_on_one(self.store_name.as_str()).unwrap();
-        let store = tx.object_store(self.store_name.as_str()).unwrap();
-        let future: OptionalJsValueFuture = store.get_owned(key.id_str().as_str()).unwrap();
-        let maybe_obj_js: Option<JsValue> = future.in_current_span().await.unwrap();
+        let store = self.get_store().await?;
 
-        if let Some(obj_js) = maybe_obj_js {
-            if obj_js.is_undefined() {
-                return Ok(None);
-            }
+        let maybe_event_js: Option<JsValue> = {
+            let maybe_value: OptionalJsValueFuture = store.get_owned(key.id_str().as_str())?;
+            maybe_value.in_current_span().await?
+        };
 
-            match Object::from_entries(&obj_js) {
-                Ok(obj_js) => {
-                    let obj_js: JsValue = JsValue::from(obj_js);
-
-                    let obj = serde_wasm_bindgen::from_value(obj_js)?;
-                    Ok(Some(obj))
-                }
-                Err(_) => Err(anyhow!("IndexedDb object error parsing")),
-            }
-        } else {
+        let Some(event_js) = maybe_event_js else {
             Ok(None)
+        };
+
+        if event_js.is_undefined() {
+            return Ok(None);
         }
+
+        let js_object = Object::from_entries(&event_js)?;
+        let obj_js: JsValue = JsValue::from(js_object);
+
+        let obj = serde_wasm_bindgen::from_value(obj_js)?;
+        Ok(Some(obj))
+    }
+
+    async fn get_key(&self, key: ObjectId) -> anyhow::Result<Option<ObjectId>> {
+        let store = self.get_store().await?;
+        let maybe_key_js: Option<JsValue> = {
+            let maybe_key = store.get_key_owned(key.id_str().as_str())?;
+            maybe_key.in_current_span().await?
+        };
+
+        let Some(key_js) = maybe_key_js else {
+            Ok(None)
+        };
+
+        if key_js.is_undefined() {
+            return Ok(None);
+        }
+
+        let js_object = Object::from_entries(&key_js)?;
+        let key_js: JsValue = JsValue::from(js_object);
+
+        let key = serde_wasm_bindgen::from_value(key_js)?;
+        Ok(Some(key))
+
     }
 }
 
 #[async_trait(? Send)]
 impl DeleteCommand for WasmRepo {
-
     #[instrument(level = Level::DEBUG)]
     async fn delete(&self, key: ObjectId) {
         let db = open_db(self.db_name.as_str()).in_current_span().await;


### PR DESCRIPTION
V2: implement PersistentObjectNavigator which allows to navigate via keys in the database (like cursor in classical databases)