### PR TITLE
Use multi-thread Tokio runtime for mobile FFI sync_wrapper

### DIFF
--- a/meta-secret/mobile/common/Cargo.toml
+++ b/meta-secret/mobile/common/Cargo.toml
@@ -10,5 +10,5 @@ anyhow.workspace = true
 tracing.workspace = true
 once_cell = "1.21.3"
 serde_json.workspace = true
-tokio = { version = "1.49.0", features = ["rt", "macros"] }
+tokio = { version = "1.49.0", features = ["rt", "rt-multi-thread", "macros"] }
 time = { version = "0.3.41", features = ["macros", "formatting"] }

--- a/meta-secret/mobile/common/src/mobile_manager.rs
+++ b/meta-secret/mobile/common/src/mobile_manager.rs
@@ -21,8 +21,12 @@ static GLOBAL_APP_MANAGER: Lazy<Mutex<Option<Arc<MobileApplicationManager>>>> =
     Lazy::new(|| Mutex::new(None));
 
 static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
-    tokio::runtime::Builder::new_current_thread()
+    // Multi-thread runtime: Kotlin Native calls FFI from worker threads (e.g. Dispatchers.IO).
+    // current_thread + block_on from another thread aborts (panic across FFI).
+    tokio::runtime::Builder::new_multi_thread()
         .enable_all()
+        .worker_threads(4)
+        .thread_name("meta-secret-mobile")
         .build()
         .expect("Failed to create Tokio runtime")
 });


### PR DESCRIPTION
## Summary
Fix TestFlight-class crash when `show_recovered` (and other mobile JSON API) runs from Kotlin Native worker threads.

## Changes
- Replace `current_thread` Tokio runtime with `multi_thread` + `worker_threads(4)` in `mobile_manager.rs`.
- Enable Tokio `rt-multi-thread` in `mobile-common` `Cargo.toml`.

## Why
`block_on` on a `current_thread` runtime from a different thread panics; FFI is invoked from `Dispatchers.IO` on iOS/KMM.

## Verification
- `cargo check -p mobile-uniffi`
- `cargo test` default bundle (core-only-test-verifier)

Made with [Cursor](https://cursor.com)