### PR TITLE
[MS-94] Redistribution flow

### DIFF
--- a/.ai/INDEX.md
+++ b/.ai/INDEX.md
@@ -4,7 +4,7 @@ Single source of truth for automation in this repo.
 
 ## Start Here
 
-1. `AGENTS.md`
+1. `.ai/README.md`
 2. `.ai/WORKFLOW.md`
 3. `.ai/PIPELINE.md`
 

--- a/.ai/README.md
+++ b/.ai/README.md
@@ -22,6 +22,19 @@ Defined in `.ai/WORKFLOW.md` and `.ai/PIPELINE.md`.
 7. Test Run
 8. Branch + Commit + PR
 
+## Domain Skills and Rules
+
+- Domain skills:
+  - `.ai/skills/core-guardian/`
+  - `.ai/skills/cli-guardian/`
+  - `.ai/skills/web-guardian/`
+  - `.ai/skills/mobile-lib-guardian/`
+- Path-scoped rules:
+  - `.ai/rules/domains/core.mdc`
+  - `.ai/rules/domains/cli.mdc`
+  - `.ai/rules/domains/web.mdc`
+  - `.ai/rules/domains/mobile-lib.mdc`
+
 ## Required Stage Logs
 
 - `Start stage <n>: <name>`

--- a/.ai/rules/common.mdc
+++ b/.ai/rules/common.mdc
@@ -1,20 +1,19 @@
 ---
-description: Common Rules
-globs: 
+description: Common cross-project rules
+globs:
 alwaysApply: true
 ---
-### Common Rules:
- - Don't write extensive documentation for almost any line of code. We need just bare minimum, only when additional explanations is needed and could be useful.
- - Strictly follow instructions in the prompt, don't try to do too much. If you really need to fix other part od the project, that os not related to what user is asking, then ask the user, if you should make the changes you need to make.
 
-### Project Structure:
- - the project is structured in the following way:
-    - [meta-secret application](mdc:meta-secret) - the main rust project, contains application logic
-    - [infra](mdc:infra) - contains infrastructure code
+# Common Rules
 
-#### Meta-Secret application, which consists of:
- - common code:
-    - [common code](mdc:meta-secret/core/src/node/common)
-    - [database](mdc:meta-secret/core/src/node/db)
- - [client](mdc:meta-secret/core/src/node/app)
- - [server](mdc:meta-secret/core/src/node/server)
+- Keep changes scoped to the user request; avoid unrelated refactors.
+- Prefer minimal comments; document only non-obvious invariants or security constraints.
+- Preserve architecture boundaries from `ARCHITECTURE.md` and security constraints from `SECURITY.md`.
+
+# Project Structure
+
+- `meta-secret/`: main Rust workspace (core, cli, meta-cli, wasm, mobile, db, server, tests).
+- `meta-secret/core/`: shared domain and crypto-centric logic.
+- `meta-secret/web-cli/ui/`: web client.
+- `meta-secret/mobile/`: mobile Rust library and UniFFI bridge.
+- `infra/`: deployment and infrastructure assets.

--- a/.ai/rules/domains/cli.mdc
+++ b/.ai/rules/domains/cli.mdc
@@ -1,0 +1,15 @@
+---
+description: CLI domain architecture/style/security constraints
+globs: meta-secret/cli/**/*.rs,meta-secret/meta-cli/**/*.rs
+alwaysApply: false
+---
+
+# CLI Domain Rules
+
+Apply these rules when editing `meta-secret/cli` or `meta-secret/meta-cli`.
+
+- Keep CLI as adapter/orchestrator; domain rules belong to `meta-secret/core`.
+- Preserve stable machine-readable output contracts for scripted usage.
+- Prefer explicit command modules and predictable exit behavior.
+- Never print raw secrets by default; redact sensitive values in errors and logs.
+- Validate user input paths and input formats before invoking core flows.

--- a/.ai/rules/domains/core.mdc
+++ b/.ai/rules/domains/core.mdc
@@ -10,6 +10,11 @@ Apply these rules when editing `meta-secret/core`.
 
 - Keep crypto and secret-sharing logic in core; do not move it to CLI/web/mobile adapters.
 - Avoid transport/framework concerns (HTTP/UI/CLI formatting) in core modules.
+- Avoid long fully-qualified `crate::...` paths in code bodies; prefer top-level `use` imports and short type/module names.
 - Use typed errors at public boundaries instead of string-based failures.
 - Do not log key material, shares, or decrypted secret payloads.
 - For behavior changes, add focused tests in the same module or crate tests.
+- Keep small local/private unit tests in the same file; move long multi-step scenarios to `meta-secret/tests/...`.
+- If a source file contains `#[cfg(test)] mod tests`, place that test module at the end of the file.
+- Current temporary policy: keep secret-sharing threshold at `K=2` for `N>=2`.
+- TODO policy target: migrate to `K=N-1` with secure resharing protocol.

--- a/.ai/rules/domains/core.mdc
+++ b/.ai/rules/domains/core.mdc
@@ -1,0 +1,15 @@
+---
+description: Core domain architecture/style/security constraints
+globs: meta-secret/core/**/*.rs
+alwaysApply: false
+---
+
+# Core Domain Rules
+
+Apply these rules when editing `meta-secret/core`.
+
+- Keep crypto and secret-sharing logic in core; do not move it to CLI/web/mobile adapters.
+- Avoid transport/framework concerns (HTTP/UI/CLI formatting) in core modules.
+- Use typed errors at public boundaries instead of string-based failures.
+- Do not log key material, shares, or decrypted secret payloads.
+- For behavior changes, add focused tests in the same module or crate tests.

--- a/.ai/rules/domains/mobile-lib.mdc
+++ b/.ai/rules/domains/mobile-lib.mdc
@@ -1,0 +1,15 @@
+---
+description: Mobile library domain architecture/style/security constraints
+globs: meta-secret/mobile/**/*.rs,meta-secret/mobile/**/*.udl
+alwaysApply: false
+---
+
+# Mobile Lib Domain Rules
+
+Apply these rules when editing `meta-secret/mobile`.
+
+- Keep UniFFI/mobile bridge thin; business and crypto logic remains in core.
+- Treat `.udl` changes as public contract changes requiring compatibility review.
+- Prefer additive API changes; avoid breaking field/type renames without migration.
+- Never leak secret data through FFI logs or debug-only paths.
+- Convert panics to controlled error responses across FFI boundaries.

--- a/.ai/rules/domains/web.mdc
+++ b/.ai/rules/domains/web.mdc
@@ -1,0 +1,15 @@
+---
+description: Web domain architecture/style/security constraints
+globs: meta-secret/web-cli/ui/**/*.vue,meta-secret/web-cli/ui/**/*.ts,meta-secret/web-cli/ui/**/*.js
+alwaysApply: false
+---
+
+# Web Domain Rules
+
+Apply these rules when editing `meta-secret/web-cli/ui`.
+
+- Keep Vue components/UI state in web; keep crypto and core business logic out of UI.
+- Use Composition API and explicit TS types for cross-module boundaries.
+- Avoid noisy debug logging; remove `console.log` from committed code.
+- Do not persist decrypted secrets in long-lived browser storage.
+- Validate/sanitize user-controlled input before rendering or routing.

--- a/.ai/skills/cli-guardian/SKILL.md
+++ b/.ai/skills/cli-guardian/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: cli-guardian
+description: Guard architecture, style, and security in cli/meta-cli changes.
+---
+
+# CLI Guardian
+
+Use this skill for edits under `meta-secret/cli/` and `meta-secret/meta-cli/`.
+
+## Focus
+
+1. Keep CLI as an adapter over core APIs.
+2. Keep command behavior predictable and script-friendly.
+3. Keep output safe and non-leaking.
+
+## Architecture rules
+
+- CLI parses args, orchestrates flows, and renders output.
+- Business logic and crypto decisions stay in `meta-secret/core`.
+- Template/render code must not duplicate domain rules from core.
+
+## Code style rules
+
+- Prefer explicit command modules per use case.
+- Keep machine-readable output stable (JSON/YAML templates).
+- Use consistent exit codes and typed error mapping.
+
+## Security rules
+
+- Never print raw secret material by default.
+- Redact or truncate sensitive identifiers in errors/logs.
+- Validate user-provided file paths and input formats before processing.
+
+## Verify before finish
+
+- `cargo test -p meta-secret-cli -p meta-cli`
+- Run a representative command manually when CLI output format changed.

--- a/.ai/skills/core-guardian/SKILL.md
+++ b/.ai/skills/core-guardian/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: core-guardian
+description: Guard architecture, style, and security in meta-secret core crate changes.
+---
+
+# Core Guardian
+
+Use this skill for edits under `meta-secret/core/` and adjacent shared Rust models.
+
+## Focus
+
+1. Keep domain and crypto logic in `meta-secret/core`.
+2. Keep transport/UI/framework concerns out of core.
+3. Preserve deterministic behavior and testability.
+
+## Architecture rules
+
+- Core owns secret split/recovery logic, crypto wrappers, and shared domain types.
+- Core must not depend on web UI, mobile UI, or CLI formatting concerns.
+- Extend behavior via explicit types and module boundaries, not by adding hidden globals.
+
+## Code style rules
+
+- Follow workspace rustfmt and existing module naming.
+- Prefer typed errors and explicit enums at crate boundaries.
+- Add comments only for invariants and non-obvious constraints.
+
+## Security rules
+
+- Never log secrets, key bytes, shares, or decrypted payloads.
+- Crypto changes require minimal diff plus focused tests.
+- Do not weaken validation paths for convenience.
+
+## Verify before finish
+
+- `cargo test -p meta-secret-core`
+- If shared contracts changed, run affected workspace package tests too.

--- a/.ai/skills/core-guardian/SKILL.md
+++ b/.ai/skills/core-guardian/SKILL.md
@@ -23,6 +23,9 @@ Use this skill for edits under `meta-secret/core/` and adjacent shared Rust mode
 
 - Follow workspace rustfmt and existing module naming.
 - Prefer typed errors and explicit enums at crate boundaries.
+- Prefer top-level `use` imports over long fully-qualified `crate::...` paths inside code.
+- Keep short unit tests for private/local behavior in the same file, but move long join/sync/recovery scenarios to `meta-secret/tests/...`.
+- If tests stay in the same file, keep `#[cfg(test)] mod tests` strictly at the end of the file.
 - Add comments only for invariants and non-obvious constraints.
 
 ## Security rules
@@ -30,6 +33,8 @@ Use this skill for edits under `meta-secret/core/` and adjacent shared Rust mode
 - Never log secrets, key bytes, shares, or decrypted payloads.
 - Crypto changes require minimal diff plus focused tests.
 - Do not weaken validation paths for convenience.
+- Temporary threshold policy: fixed `K=2` for `N>=2`.
+- TODO: migrate threshold strategy to `K=N-1` after protocol hardening.
 
 ## Verify before finish
 

--- a/.ai/skills/mobile-lib-guardian/SKILL.md
+++ b/.ai/skills/mobile-lib-guardian/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: mobile-lib-guardian
+description: Guard architecture, style, and security in mobile/uniffi library changes.
+---
+
+# Mobile Lib Guardian
+
+Use this skill for edits under `meta-secret/mobile/` and UniFFI bridge surfaces.
+
+## Focus
+
+1. Keep Rust mobile library ABI/API stable.
+2. Keep FFI layer thin over core logic.
+3. Prevent leaks across FFI boundaries.
+
+## Architecture rules
+
+- `mobile/uniffi` defines exported contract and should delegate to core/common modules.
+- `mobile/common` may adapt data and platform helpers, but not reimplement core domain logic.
+- Any `.udl` surface change must be treated as a versioned contract change.
+
+## Code style rules
+
+- Keep FFI types explicit and serialization stable.
+- Prefer additive API evolution over breaking changes.
+- Keep bridge code small and testable.
+
+## Security rules
+
+- Never expose raw key material or decrypted secrets via logs or debug helpers.
+- Validate all FFI input size/format at boundary entry.
+- Treat panic propagation across FFI as a bug: return controlled errors.
+
+## Verify before finish
+
+- `cargo test -p metasecret_mobile`
+- `cargo run -p uniffi-bindgen-runner --bin uniffi-bindgen` when interface changed.

--- a/.ai/skills/web-guardian/SKILL.md
+++ b/.ai/skills/web-guardian/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: web-guardian
+description: Guard architecture, style, and security in web-cli/ui changes.
+---
+
+# Web Guardian
+
+Use this skill for edits under `meta-secret/web-cli/ui/` and WASM-facing web integration points.
+
+## Focus
+
+1. Keep UI thin over API/core contracts.
+2. Keep component state and routing explicit.
+3. Prevent client-side leaks of secret data.
+
+## Architecture rules
+
+- Vue components should orchestrate UI state, not embed crypto/domain logic.
+- Shared business rules must live in Rust core/WASM contracts.
+- Keep boundaries clear between router, UI components, and API managers.
+
+## Code style rules
+
+- Use Vue Composition API.
+- Prefer strongly typed TS interfaces at boundaries.
+- Keep component-scoped styles and avoid noisy debug logging.
+
+## Security rules
+
+- Do not persist decrypted secrets to long-lived browser storage.
+- Avoid logging sensitive payloads in browser console and telemetry.
+- Validate and sanitize all external input before rendering.
+
+## Verify before finish
+
+- `cd meta-secret/web-cli/ui && npm run build`
+- Run targeted unit/e2e tests when routes or auth-relevant paths change.

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ infra/.secret
 /meta-secret/meta-cli/example/b
 /meta-secret/meta-cli/example/c
 /infra/Taskfile.yml
+
+# AI
+.ai/artifacts/run

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,4 +35,4 @@ Meta Secret core is organized as a **Cargo workspace** of crates. The **`meta-se
 ## Further reading
 
 - [PROJECT_CONTEXT.md](PROJECT_CONTEXT.md) — paths and commands.
-- `.claude/skills/architecture-guardian/SKILL.md` — short checklist for agents (align with this file).
+- [`.ai/skills/architecture-guardian/SKILL.md`](.ai/skills/architecture-guardian/SKILL.md) — short checklist for agents (align with this file).

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -6,6 +6,9 @@
 - **Naming:** Follow Rust API guidelines (`snake_case` for functions/modules, `PascalCase` for types).
 - **Errors:** Prefer typed errors (`thiserror` / explicit enums) at boundaries; avoid stringly-typed failures in public APIs.
 - **Async:** Use the stack already present in each crate (`async-std` / `tokio` as applicable); do not mix runtimes in one module without a strong reason.
+- **Imports:** Avoid fully qualified `crate::...` paths in function bodies/type positions when `use` imports can be used. Prefer importing modules/types at the top of the file and referencing short names in code.
+- **Test placement:** Keep small unit tests close to the module they validate (same file) only when they test local/private logic. Put long multi-step scenarios (sync/join/recovery flows) in `meta-secret/tests/...` integration tests.
+- **Test block order:** If tests are in the same source file (`#[cfg(test)] mod tests`), keep that module at the end of the file, after all production code.
 
 ## Tests
 

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -30,7 +30,7 @@ cargo test -p meta-secret-core
 cargo build --release -p meta-server
 ```
 
-Project-wide Docker builds/tests (see root [README.md](README.md) and [`.cursor/rules/build/`](.cursor/rules/build/)):
+Project-wide Docker builds/tests (see root [README.md](README.md) and [`.ai/rules/build/`](.ai/rules/build/)):
 
 ```bash
 docker buildx bake test

--- a/README.md
+++ b/README.md
@@ -87,27 +87,28 @@ This repository defines a **phased workflow** (plan → implement → test → v
 | [SECURITY.md](SECURITY.md) | Keys, logging, crypto hygiene. |
 | [CODE_STYLE.md](CODE_STYLE.md) | Rust conventions. |
 
-Skills live under [`.claude/skills/`](.claude/skills/). Subagent prompts: [`.cursor/agents/`](.cursor/agents/) and [`.claude/agents/`](.claude/agents/).
+Skills live under [`.ai/skills/`](.ai/skills/). Subagent prompts live under [`.ai/agents/`](.ai/agents/).
+Domain map for web/cli/core/mobile lib: [docs/ai-domain-standards.md](docs/ai-domain-standards.md).
 
 ---
 
 ### Claude Code
 
 1. Open **this repo** in Claude Code so it loads [`.claude/`](.claude/).
-2. **Slash commands:** [`.claude/commands/`](.claude/commands/).
+2. Use workflow command specs in [`.ai/commands/`](.ai/commands/) (invoked through Claude entrypoints).
 
 **Start a full delivery chain**
 
 | Command | When |
 |---------|------|
-| `/workflow-from-issue` | GitLab issue number or URL (`glab` available). |
+| `/workflow-from-issue` | GitHub issue number or URL (`gh` available). |
 | `/workflow-from-prompt` | Free-text feature/bug description only. |
 
 **Run a single phase**
 
 | Command | Phase |
 |---------|--------|
-| `/only-issue-coordinator` | GitLab issue summary |
+| `/only-issue-coordinator` | GitHub issue summary |
 | `/only-planner` | Plan only (`feature-planner`) |
 | `/only-implementer` | Implement approved plan |
 | `/only-test-author` | Add/update tests |
@@ -126,11 +127,11 @@ Skills live under [`.claude/skills/`](.claude/skills/). Subagent prompts: [`.cur
 
 ### Cursor
 
-Cursor does **not** load `.claude/commands/` as slash commands. Use **Agent** chat; parity: [`.cursor/commands/README.md`](.cursor/commands/README.md).
+Cursor does **not** load Claude slash command folders directly. Use **Agent** chat; parity: [`.cursor/commands/README.md`](.cursor/commands/README.md).
 
-1. **Rules:** [`.cursor/rules/`](.cursor/rules/) — `ai-project-context.mdc` pulls the root markdown documents.
-2. **Invoke a phase:** `/feature-planner` or “Use the **feature-planner** subagent: …” — see [`.cursor/agents/`](.cursor/agents/).
-3. **Skills:** ask Agent to read `SKILL.md` under [`.claude/skills/<name>/`](.claude/skills/) when needed.
+1. **Rules:** [`.ai/rules/`](.ai/rules/) — `ai-project-context.mdc` pulls the root markdown documents.
+2. **Invoke a phase:** use workflow entrypoints from [`.ai/commands/`](.ai/commands/).
+3. **Skills:** ask Agent to read `SKILL.md` under [`.ai/skills/<name>/`](.ai/skills/) when needed.
 4. **Pipeline:** [WORKFLOW.md](WORKFLOW.md). **FFI changes:** coordinate with **meta-secret-compose**.
 
 ---

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -19,7 +19,7 @@ This document describes the **multi-phase delivery pipeline** for **meta-secret-
 | Release / MR | `release-manager` | Branch from `main`, commit/push only after explicit user ok |
 | Pattern → skill/command (optional) | `workflow-pattern-capture` | 0–2 durable suggestions or “no change”; not every MR |
 
-Files: [`.cursor/agents/`](.cursor/agents/) and [`.claude/agents/`](.claude/agents/) (same prompts; frontmatter may differ).
+Files: [`.ai/agents/`](.ai/agents/) with IDE entrypoints in `.claude/`, `.cursor/`, and `.codex/`.
 
 ## Two entry points (same pipeline after planning)
 
@@ -46,7 +46,7 @@ After the first approved plan, the pipeline is identical.
 
 **If green:** `code-reviewer` → if must-fix items → back to **Plan** → **Implement** (and tests as needed).
 
-**If review ok:** `release-notes` (draft MR body) → approve → `release-manager` (branch from `main`, **commit and push only after explicit “ok”**, MR via `glab` when available).
+**If review ok:** `release-notes` (draft MR body) → approve → `release-manager` (branch from `main`, **commit and push only after explicit “ok”**, MR via `gh` when available).
 
 **Optional — pattern capture (not every MR):** when a **trigger** applies—large feature, **new** error class, **same** review correction **three or more** times, or **toolchain/stack** change—run **`workflow-pattern-capture`** (skill **`workflow-pattern-capture`**) after `code-reviewer` or after `release-notes`. Output is **0–2** concrete proposals (skill, command, Cursor rule, or justified Claude hook) **or** **No changes recommended**. Skip for trivial fixes.
 
@@ -58,23 +58,27 @@ After **every** phase, require a clear **artifact** (summary, plan, diff, test r
 
 You can invoke **any** subagent alone with a direct prompt (logs, files, partial context):
 
-- **Claude Code:** delegate to the named subagent or use slash commands under [`.claude/commands/`](.claude/commands/) (`/only-planner`, `/only-implementer`, etc.).
-- **Cursor:** in Agent chat, use `/subagent-name` or natural language (“use the feature-planner subagent to …”). See [`.cursor/commands/README.md`](.cursor/commands/README.md) for parity.
+- **Claude Code / Codex CLI:** use workflow entries and phase docs under [`.ai/commands/`](.ai/commands/) (`workflow-from-issue`, `only-planner`, etc.).
+- **Cursor:** use workflow bootstrap in [`.cursor/WORKFLOW.md`](.cursor/WORKFLOW.md), which delegates to [`.ai/WORKFLOW.md`](.ai/WORKFLOW.md).
 
 ## Skills (templates)
 
 | Skill folder | Use |
 |--------------|-----|
-| `workflow-issue-handoff` | Build **Summary** after `gh issue view` (or `glab issue view`) |
+| `workflow-issue-handoff` | Build **Summary** after `gh issue view` |
 | `workflow-manual-task-brief` | Structure a manual task before planning |
 | `workflow-plan-output` | Plan shape; aligns with `write-implementation-plan` |
 | `workflow-mr-body` | MR title/body checklist |
 | `systematic-debugging` | Loaded by `debug-rca` (Claude) or read explicitly |
 | `workflow-pattern-capture` | Optional: repeating patterns → skill/command/rule/hook; cap 0–2 |
 | `architecture-guardian` | Layer/boundary checks for agents |
+| `core-guardian` | Rules for `meta-secret/core` (architecture/style/security) |
+| `cli-guardian` | Rules for `cli` and `meta-cli` layers |
+| `web-guardian` | Rules for `web-cli/ui` layer |
+| `mobile-lib-guardian` | Rules for `mobile/uniffi` and mobile-common FFI layer |
 | `write-implementation-plan` | Deeper plan template |
 
-Paths: [`.claude/skills/`](.claude/skills/).
+Paths: [`.ai/skills/`](.ai/skills/).
 
 ## Tool limits
 

--- a/docs/ai-domain-standards.md
+++ b/docs/ai-domain-standards.md
@@ -1,0 +1,19 @@
+# AI Domain Standards
+
+Domain-level standards for architecture, code style, and security in `meta-secret-core`.
+
+## Domains
+
+| Domain | Skill | Rule |
+|---|---|---|
+| Core | [`.ai/skills/core-guardian/SKILL.md`](../.ai/skills/core-guardian/SKILL.md) | [`.ai/rules/domains/core.mdc`](../.ai/rules/domains/core.mdc) |
+| CLI | [`.ai/skills/cli-guardian/SKILL.md`](../.ai/skills/cli-guardian/SKILL.md) | [`.ai/rules/domains/cli.mdc`](../.ai/rules/domains/cli.mdc) |
+| Web | [`.ai/skills/web-guardian/SKILL.md`](../.ai/skills/web-guardian/SKILL.md) | [`.ai/rules/domains/web.mdc`](../.ai/rules/domains/web.mdc) |
+| Mobile lib | [`.ai/skills/mobile-lib-guardian/SKILL.md`](../.ai/skills/mobile-lib-guardian/SKILL.md) | [`.ai/rules/domains/mobile-lib.mdc`](../.ai/rules/domains/mobile-lib.mdc) |
+
+## Global references
+
+- [ARCHITECTURE.md](../ARCHITECTURE.md)
+- [CODE_STYLE.md](../CODE_STYLE.md)
+- [SECURITY.md](../SECURITY.md)
+- [WORKFLOW.md](../WORKFLOW.md)

--- a/docs/ai-skills.md
+++ b/docs/ai-skills.md
@@ -5,4 +5,4 @@ This file is **not** the primary guide. Use:
 - **[README.md — AI-assisted development](../README.md#ai-assisted-development)** — onboarding for **Claude Code** vs **Cursor**.
 - **[WORKFLOW.md](../WORKFLOW.md)** — phased pipeline, agents, skills.
 
-Legacy or external docs may mention old slash names; [`.claude/commands/`](../.claude/commands/) and [WORKFLOW.md](../WORKFLOW.md) are authoritative.
+Legacy or external docs may mention old slash names; [`.ai/commands/`](../.ai/commands/) and [WORKFLOW.md](../WORKFLOW.md) are authoritative.

--- a/meta-secret/core/src/node/app/app_manager_shared.rs
+++ b/meta-secret/core/src/node/app/app_manager_shared.rs
@@ -1,0 +1,116 @@
+use anyhow::{Result, bail};
+use std::sync::Arc;
+
+use crate::crypto::keys::TransportSk;
+use crate::node::app::meta_app::meta_client_service::{
+    MetaClientDataTransfer, MetaClientService, MetaClientStateProvider,
+};
+use crate::node::app::sync::sync_gateway::SyncGateway;
+use crate::node::app::sync::sync_protocol::{HttpSyncProtocol, SyncProtocol};
+use crate::node::common::data_transfer::MpscDataTransfer;
+use crate::node::common::model::device::common::{DeviceName, DeviceType};
+use crate::node::common::model::meta_pass::MetaPasswordId;
+use crate::node::common::model::secret::ClaimId;
+use crate::node::common::model::user::common::UserDataOutsiderStatus;
+use crate::node::common::model::user::user_creds::UserCreds;
+use crate::node::common::model::vault::vault::VaultName;
+use crate::node::common::model::{ApplicationState, VaultFullInfo};
+use crate::node::db::actions::recover::RecoveryHandler;
+use crate::node::db::objects::persistent_object::PersistentObject;
+use crate::node::db::repo::generic_db::KvLogEventRepo;
+use crate::node::db::repo::persistent_credentials::PersistentCredentials;
+use crate::secret::shared_secret::PlainText;
+
+pub fn resolve_signup_vault_name(state: &ApplicationState) -> Result<VaultName> {
+    match state {
+        ApplicationState::Local(_) => {
+            bail!("Sign up is not allowed in local state");
+        }
+        ApplicationState::Vault(vault_info) => match vault_info {
+            VaultFullInfo::NotExists(user) => Ok(user.vault_name.clone()),
+            VaultFullInfo::Outsider(outsider) => match outsider.status {
+                UserDataOutsiderStatus::NonMember => Ok(outsider.user_data.vault_name.clone()),
+                UserDataOutsiderStatus::Pending => {
+                    bail!("Sign up is not allowed in pending state");
+                }
+                UserDataOutsiderStatus::Declined => {
+                    bail!("Sign up is not allowed in declined state");
+                }
+            },
+            VaultFullInfo::Member(_) => {
+                bail!("Sign up is not allowed in vault state");
+            }
+        },
+    }
+}
+
+pub fn find_recovery_claim_id_from_state(
+    state: &ApplicationState,
+    pass_id: &MetaPasswordId,
+) -> Option<ClaimId> {
+    let ApplicationState::Vault(VaultFullInfo::Member(member)) = state else {
+        return None;
+    };
+
+    member.ss_claims.find_recovery_claim_id(pass_id)
+}
+
+pub async fn recover_plain_text<Repo: KvLogEventRepo, SyncP: SyncProtocol>(
+    sync_gateway: &SyncGateway<Repo, SyncP>,
+    user_creds: UserCreds,
+    claim_id: ClaimId,
+    pass_id: MetaPasswordId,
+) -> Result<PlainText> {
+    let recovery_handler = RecoveryHandler {
+        p_obj: sync_gateway.p_obj.clone(),
+    };
+
+    recovery_handler
+        .recover(user_creds, claim_id, pass_id)
+        .await
+}
+
+pub async fn build_client_components<Repo: KvLogEventRepo>(
+    client_repo: Arc<Repo>,
+    sync_protocol: Arc<HttpSyncProtocol>,
+    master_key: TransportSk,
+    device_name: DeviceName,
+    device_type: DeviceType,
+) -> Result<(
+    Arc<SyncGateway<Repo, HttpSyncProtocol>>,
+    Arc<MetaClientService<Repo, HttpSyncProtocol>>,
+)> {
+    let p_obj = Arc::new(PersistentObject::new(client_repo));
+
+    let creds_repo = PersistentCredentials {
+        p_obj: p_obj.clone(),
+        master_key: master_key.clone(),
+    };
+    let device_creds = Arc::new(
+        creds_repo
+            .get_or_generate_device_creds_with_type(device_name, device_type)
+            .await?,
+    );
+
+    let sync_gateway = Arc::new(SyncGateway {
+        id: String::from("client-gateway"),
+        p_obj: p_obj.clone(),
+        sync: sync_protocol,
+        master_key: master_key.clone(),
+    });
+
+    let state_provider = Arc::new(MetaClientStateProvider::new());
+
+    let meta_client_service = Arc::new(MetaClientService {
+        data_transfer: Arc::new(MetaClientDataTransfer {
+            dt: MpscDataTransfer::new(),
+        }),
+        sync_gateway: sync_gateway.clone(),
+        state_provider,
+        p_obj,
+        device_data: device_creds.device.clone(),
+        master_key,
+    });
+
+    Ok((sync_gateway, meta_client_service))
+}

--- a/meta-secret/core/src/node/app/mod.rs
+++ b/meta-secret/core/src/node/app/mod.rs
@@ -1,3 +1,4 @@
+pub mod app_manager_shared;
 pub mod meta_app;
 pub mod orchestrator;
 pub mod sync;

--- a/meta-secret/core/src/node/app/orchestrator.rs
+++ b/meta-secret/core/src/node/app/orchestrator.rs
@@ -1,14 +1,18 @@
+use crate::node::common::model::crypto::aead::EncryptedMessage;
+use crate::node::common::model::meta_pass::{PlainPassInfo, SecurePassInfo};
 use crate::node::common::model::secret::{
-    ClaimId, SecretDistributionData, SecretDistributionType, SsClaim, SsDeclineData, SsLogData,
+    ClaimId, SecretDistributionData, SecretDistributionType, SsClaim, SsDeclineData,
+    SsDistributionId, SsDistributionStatus, SsLogData,
 };
 use crate::node::common::model::user::common::{UserDataMember, UserMembership};
 use crate::node::common::model::user::user_creds::UserCreds;
 use crate::node::common::model::vault::vault::{VaultMember, VaultStatus};
 use crate::node::common::model::vault::vault_data::VaultData;
 use crate::node::db::actions::sign_up::join::{JoinAction, JoinActionUpdate};
+use crate::node::db::descriptors::shared_secret_descriptor::SsDeviceLogDescriptor;
 use crate::node::db::descriptors::shared_secret_descriptor::SsWorkflowDescriptor;
 use crate::node::db::events::kv_log_event::{KvKey, KvLogEvent};
-use crate::node::db::events::shared_secret_event::SsWorkflowObject;
+use crate::node::db::events::shared_secret_event::{SsDeviceLogObject, SsWorkflowObject};
 use crate::node::db::events::vault::vault_log_event::{
     JoinClusterEvent, VaultActionRequestEvent, VaultLogObject,
 };
@@ -16,9 +20,13 @@ use crate::node::db::objects::persistent_object::PersistentObject;
 use crate::node::db::objects::persistent_shared_secret::PersistentSharedSecret;
 use crate::node::db::objects::persistent_vault::PersistentVault;
 use crate::node::db::repo::generic_db::KvLogEventRepo;
+use crate::recover_from_shares;
+use crate::secret::split2;
+use crate::secret::shared_secret::{PlainText, UserShareDto};
 use anyhow::bail;
 use anyhow::Result;
 use log::debug;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 /// Contains business logic of secrets management and login/sign-up actions.
@@ -64,9 +72,7 @@ impl<Repo: KvLogEventRepo> MetaOrchestrator<Repo> {
 
         Ok(())
     }
-}
 
-impl<Repo: KvLogEventRepo> MetaOrchestrator<Repo> {
     pub async fn accept_recover(&self, claim_id: ClaimId) -> Result<()> {
         let member = self.get_member().await?;
         let vault = self.get_vault(member).await?;
@@ -159,6 +165,19 @@ impl<Repo: KvLogEventRepo> MetaOrchestrator<Repo> {
                         };
 
                         join_action.update(db_join_request, upd.clone()).await?;
+
+                        if let JoinActionUpdate::Accept = upd {
+                            let redistribution_vault = vault.clone().update_membership(
+                                UserMembership::Member(UserDataMember {
+                                    user_data: join_request.candidate.clone(),
+                                }),
+                            );
+                            self.redistribute_existing_secrets(
+                                &redistribution_vault,
+                                &join_request,
+                            )
+                                .await?;
+                        }
                     }
                 }
                 VaultActionRequestEvent::AddMetaPass(_) => {
@@ -170,6 +189,15 @@ impl<Repo: KvLogEventRepo> MetaOrchestrator<Repo> {
         Ok(())
     }
 
+    #[cfg(any(test, feature = "test-framework"))]
+    pub async fn redistribute_existing_secrets_for_test(
+        &self,
+        vault: &VaultData,
+        join_request: &JoinClusterEvent,
+    ) -> Result<()> {
+        self.redistribute_existing_secrets(vault, join_request).await
+    }
+
     async fn get_vault(&self, member: UserDataMember) -> Result<VaultData> {
         let p_vault = PersistentVault::from(self.p_obj());
         let vault = p_vault
@@ -177,6 +205,202 @@ impl<Repo: KvLogEventRepo> MetaOrchestrator<Repo> {
             .await?
             .to_data();
         Ok(vault)
+    }
+
+    async fn redistribute_existing_secrets(
+        &self,
+        vault: &VaultData,
+        join_request: &JoinClusterEvent,
+    ) -> Result<()> {
+        let joined_device_id = join_request.candidate.device.device_id.clone();
+        let local_device_id = self.user_creds.device_id().clone();
+        let p_ss = PersistentSharedSecret::from(self.p_obj.clone());
+        let mut ss_log_data = self.get_ss_log_data().await?;
+        let mut members = vault.members();
+        members.sort_by_key(|member| member.user().device.device_id.to_string());
+
+        for pass_id in vault.secrets.iter() {
+            let mut split_claim = ss_log_data
+                .claims
+                .values()
+                .find(|claim| {
+                    claim.distribution_type == SecretDistributionType::Split
+                        && claim.sender.eq(&local_device_id)
+                        && claim.dist_claim_id.pass_id.eq(pass_id)
+                })
+                .cloned();
+            if split_claim.is_none() {
+                let local_claim_events = self
+                    .p_obj
+                    .get_object_events_from_beginning(
+                        SsDeviceLogDescriptor::from(local_device_id.clone()),
+                    )
+                    .await?;
+                split_claim = local_claim_events
+                    .into_iter()
+                    .map(|obj: SsDeviceLogObject| {
+                        obj.to_distribution_request()
+                    })
+                    .find(|claim| {
+                        claim.distribution_type == SecretDistributionType::Split
+                            && claim.sender.eq(&local_device_id)
+                            && claim.dist_claim_id.pass_id.eq(pass_id)
+                    });
+            }
+            let Some(mut split_claim) = split_claim else {
+                continue;
+            };
+
+            let target_desc = SsWorkflowDescriptor::Distribution(SsDistributionId {
+                pass_id: pass_id.clone(),
+                receiver: joined_device_id.clone(),
+            });
+            let has_target_distribution = self.p_obj.find_tail_event(target_desc).await?.is_some();
+            let claim_already_contains_joined =
+                split_claim.receivers.iter().any(|d| d.eq(&joined_device_id));
+            if has_target_distribution && claim_already_contains_joined {
+                continue;
+            }
+
+            let source_desc = SsWorkflowDescriptor::Distribution(SsDistributionId {
+                pass_id: pass_id.clone(),
+                receiver: local_device_id.clone(),
+            });
+            let Some(source_event) = self.p_obj.find_tail_event(source_desc).await? else {
+                debug!(
+                    "Skip redistribution for pass {}, source share for local device not found",
+                    pass_id.name
+                );
+                continue;
+            };
+
+            let SsWorkflowObject::Distribution(source_dist) = source_event else {
+                continue;
+            };
+
+            let source_plain = source_dist
+                .value
+                .secret_message
+                .cipher_text()
+                .decrypt(&self.user_creds.device_creds.secret_box.transport.sk)?;
+            let source_share = UserShareDto::try_from(&source_plain.msg)?;
+
+            let shares_needed = source_share
+                .share_blocks
+                .first()
+                .map(|block| block.config.threshold)
+                .unwrap_or(1)
+                .max(1);
+
+            let mut shares_for_recovery: Vec<UserShareDto> = vec![source_share.clone()];
+            let mut collected_share_ids: HashSet<usize> = HashSet::from([source_share.share_id]);
+
+            let mut candidate_devices: Vec<_> = members
+                .iter()
+                .map(|member| member.user().device.device_id.clone())
+                .collect();
+            candidate_devices.sort_by_key(|device_id| device_id.to_string());
+            candidate_devices.dedup();
+
+            for receiver in candidate_devices {
+                if shares_for_recovery.len() >= shares_needed {
+                    break;
+                }
+                if receiver.eq(&local_device_id) {
+                    continue;
+                }
+
+                let dist_desc = SsWorkflowDescriptor::Distribution(SsDistributionId {
+                    pass_id: pass_id.clone(),
+                    receiver,
+                });
+                let Some(dist_event) = self.p_obj.find_tail_event(dist_desc).await? else {
+                    continue;
+                };
+
+                let SsWorkflowObject::Distribution(dist) = dist_event else {
+                    continue;
+                };
+
+                let decrypted = match dist
+                    .value
+                    .secret_message
+                    .cipher_text()
+                    .decrypt(&self.user_creds.device_creds.secret_box.transport.sk)
+                {
+                    Ok(plain) => plain,
+                    Err(_) => continue,
+                };
+
+                let share = match UserShareDto::try_from(&decrypted.msg) {
+                    Ok(share) => share,
+                    Err(_) => continue,
+                };
+
+                if collected_share_ids.insert(share.share_id) {
+                    shares_for_recovery.push(share);
+                }
+            }
+
+            if shares_for_recovery.len() < shares_needed {
+                debug!(
+                    "Skip redistribution for pass {}: not enough shares to recover (need {}, got {})",
+                    pass_id.name,
+                    shares_needed,
+                    shares_for_recovery.len()
+                );
+                continue;
+            }
+
+            let plain_secret = recover_from_shares(shares_for_recovery)?;
+            let secure_pass = SecurePassInfo::from(PlainPassInfo {
+                pass_id: pass_id.clone(),
+                pass: plain_secret.text,
+            });
+            let re_split = split2(secure_pass, vault.sss_cfg())?;
+
+            if re_split.shares.len() != members.len() {
+                bail!("Invalid state: shares count does not match vault members count");
+            }
+
+            for (idx, receiver) in members.iter().enumerate() {
+                let receiver_pk = &receiver.user().device.keys.transport_pk;
+                let share_json = re_split.shares[idx].as_json()?;
+                let encrypted = self
+                    .user_creds
+                    .device_creds
+                    .key_manager()?
+                    .transport
+                    .encrypt_string(PlainText::from(share_json), receiver_pk)?;
+
+                let dist_id = SsDistributionId {
+                    pass_id: pass_id.clone(),
+                    receiver: receiver.user().device.device_id.clone(),
+                };
+
+                let wf = SsWorkflowObject::Distribution(KvLogEvent {
+                    key: KvKey::from(SsWorkflowDescriptor::Distribution(dist_id)),
+                    value: SecretDistributionData {
+                        vault_name: source_dist.value.vault_name.clone(),
+                        claim_id: split_claim.dist_claim_id.clone(),
+                        secret_message: EncryptedMessage::CipherShare { share: encrypted },
+                    },
+                });
+                self.p_obj.repo.save(wf).await?;
+            }
+
+            if !split_claim.receivers.iter().any(|d| d.eq(&joined_device_id)) {
+                split_claim.receivers.push(joined_device_id.clone());
+            }
+            split_claim
+                .status
+                .statuses
+                .insert(joined_device_id.clone(), SsDistributionStatus::Pending);
+            p_ss.save_ss_log_event(split_claim.clone()).await?;
+            ss_log_data.claims.insert(split_claim.id.clone(), split_claim);
+        }
+
+        Ok(())
     }
 
     async fn get_vault_log_event(&self, member: &UserDataMember) -> Result<Option<VaultLogObject>> {
@@ -280,5 +504,142 @@ impl<Repo: KvLogEventRepo> MetaOrchestrator<Repo> {
 
     fn p_obj(&self) -> Arc<PersistentObject<Repo>> {
         self.p_obj.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::node::common::model::meta_pass::{MetaPasswordId, PlainPassInfo, SecurePassInfo};
+    use crate::meta_tests::fixture_util::fixture::FixtureRegistry;
+    use crate::meta_tests::fixture_util::fixture::states::EmptyState;
+    use crate::node::common::model::secret::SsDistributionId;
+    use crate::node::common::model::vault::vault_data::VaultData;
+    use crate::node::db::events::shared_secret_event::SsWorkflowObject;
+    use crate::node::db::in_mem_db::InMemKvLogEventRepo;
+    use crate::secret::MetaDistributor;
+    use anyhow::Result;
+
+    async fn prepare_single_device_secret() -> Result<(
+        FixtureRegistry<EmptyState>,
+        MetaOrchestrator<InMemKvLogEventRepo>,
+        VaultData,
+        MetaPasswordId,
+    )> {
+        let registry = FixtureRegistry::empty();
+        let client_user_creds = registry.state.user_creds.client.clone();
+        let client_member = registry.state.vault_data.client_membership.user_data_member();
+        let single_member_vault = VaultData::from(client_member.clone());
+
+        let vault_member = VaultMember {
+            member: client_member,
+            vault: single_member_vault.clone(),
+        };
+
+        let pass_info = PlainPassInfo::new("late_join_secret".to_string(), "2bee|~".to_string());
+        let secure_pass = SecurePassInfo::from(pass_info);
+        let pass_id = secure_pass.pass_id.clone();
+
+        let distributor = MetaDistributor {
+            p_obj: registry.state.p_obj.client.clone(),
+            user_creds: Arc::new(client_user_creds.clone()),
+            vault_member: vault_member.clone(),
+        };
+        distributor
+            .distribute(vault_member.clone(), secure_pass)
+            .await?;
+
+        // In this unit test we do not run server sync, so seed ss_log explicitly.
+        let p_ss = PersistentSharedSecret::from(registry.state.p_obj.client.clone());
+        let seeded_claim = vault_member.create_split_claim(pass_id.clone());
+        p_ss.save_ss_log_event(seeded_claim).await?;
+
+        let orchestrator = MetaOrchestrator {
+            p_obj: registry.state.p_obj.client.clone(),
+            user_creds: client_user_creds,
+        };
+
+        Ok((registry, orchestrator, single_member_vault, pass_id))
+    }
+
+    #[tokio::test]
+    async fn test_redistribute_existing_secret_on_join_accept() -> Result<()> {
+        let (registry, orchestrator, single_member_vault, pass_id) =
+            prepare_single_device_secret().await?;
+
+        let joined_member = registry.state.vault_data.vd_membership.user_data_member();
+        let updated_vault = single_member_vault
+            .update_membership(UserMembership::Member(joined_member.clone()))
+            .add_secret(pass_id.clone());
+
+        let join_request = JoinClusterEvent {
+            candidate: joined_member.user().clone(),
+        };
+
+        orchestrator
+            .redistribute_existing_secrets(&updated_vault, &join_request)
+            .await?;
+
+        let target_desc = SsWorkflowDescriptor::Distribution(SsDistributionId {
+            pass_id: pass_id.clone(),
+            receiver: joined_member.user().device.device_id.clone(),
+        });
+        let target_event = orchestrator.p_obj.find_tail_event(target_desc).await?;
+        assert!(
+            target_event.is_some(),
+            "Distribution for newly joined member must be created"
+        );
+
+        let Some(SsWorkflowObject::Distribution(dist)) = target_event else {
+            panic!("Expected distribution workflow object");
+        };
+
+        let joined_sk = &registry
+            .state
+            .user_creds
+            .vd
+            .device_creds
+            .secret_box
+            .transport
+            .sk;
+        let decrypted = dist.value.secret_message.cipher_text().decrypt(joined_sk)?;
+        let share_json = String::try_from(&decrypted.msg)?;
+        assert!(
+            share_json.contains("share_id"),
+            "Redistributed payload must contain a valid share"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_redistribute_existing_secret_is_idempotent() -> Result<()> {
+        let (registry, orchestrator, single_member_vault, pass_id) =
+            prepare_single_device_secret().await?;
+
+        let joined_member = registry.state.vault_data.vd_membership.user_data_member();
+        let updated_vault = single_member_vault
+            .update_membership(UserMembership::Member(joined_member.clone()))
+            .add_secret(pass_id.clone());
+        let join_request = JoinClusterEvent {
+            candidate: joined_member.user().clone(),
+        };
+
+        orchestrator
+            .redistribute_existing_secrets(&updated_vault, &join_request)
+            .await?;
+        let db_len_after_first = orchestrator.p_obj.repo.get_db().await.len();
+
+        orchestrator
+            .redistribute_existing_secrets(&updated_vault, &join_request)
+            .await?;
+        let db_len_after_second = orchestrator.p_obj.repo.get_db().await.len();
+
+        assert_eq!(
+            db_len_after_first, db_len_after_second,
+            "Second redistribution run must not create additional events"
+        );
+
+        Ok(())
     }
 }

--- a/meta-secret/core/src/node/app/sync/sync_gateway.rs
+++ b/meta-secret/core/src/node/app/sync/sync_gateway.rs
@@ -210,13 +210,14 @@ impl<Repo: KvLogEventRepo, Sync: SyncProtocol> SyncGateway<Repo, Sync> {
 
                         for wf_event in wf_events {
                             if claim.sender.eq(&user.device.device_id) {
-                                let obj_id = wf_event.obj_id();
+                                // Keep local split distributions so sender can perform future
+                                // redistributions for new members under current K=2 policy.
+                                // TODO(security): revisit retention strategy when migrating to K=N-1 resharing.
                                 let request = {
                                     let event = WriteSyncRequest::Event(wf_event.to_generic());
                                     SyncRequest::Write(Box::from(event))
                                 };
                                 self.sync.send(request).await?;
-                                self.p_obj.repo.delete(obj_id).await;
                             }
                         }
                     }

--- a/meta-secret/core/src/node/common/model/vault/vault_data.rs
+++ b/meta-secret/core/src/node/common/model/vault/vault_data.rs
@@ -321,12 +321,12 @@ mod test {
 
         let vault_data = vault_data.update_membership(vd_membership);
         let cfg = vault_data.sss_cfg();
-        assert_eq!(cfg.threshold, 1);
+        assert_eq!(cfg.threshold, 2);
         assert_eq!(cfg.number_of_shares, 2);
 
         let vault_data = vault_data.update_membership(client_b_membership);
         let cfg = vault_data.sss_cfg();
-        assert_eq!(cfg.threshold, 1);
+        assert_eq!(cfg.threshold, 2);
         assert_eq!(cfg.number_of_shares, 2);
 
         assert_eq!(2, vault_data.members().len());

--- a/meta-secret/core/src/node/db/actions/recover.rs
+++ b/meta-secret/core/src/node/db/actions/recover.rs
@@ -91,12 +91,7 @@ impl<Repo: KvLogEventRepo> RecoveryHandler<Repo> {
             pass_id,
             receiver: user_creds.device_id().clone(),
         });
-        let dist = self
-            .p_obj
-            .find_tail_event(desc)
-            .await?
-            .unwrap()
-            .to_distribution_data()?;
+        let maybe_dist = self.p_obj.find_tail_event(desc).await?;
 
         // Extract all SecretDistributionData objects from recoveries and dists
         let recovery_data: Vec<SecretDistributionData> = recoveries
@@ -104,7 +99,15 @@ impl<Repo: KvLogEventRepo> RecoveryHandler<Repo> {
             .map(|r| r.to_distribution_data())
             .collect::<Result<Vec<_>, _>>()?;
 
-        let distribution_data = vec![dist];
+        let distribution_data: Vec<SecretDistributionData> = maybe_dist
+            .map(|dist| dist.to_distribution_data())
+            .transpose()?
+            .into_iter()
+            .collect();
+
+        if recovery_data.is_empty() && distribution_data.is_empty() {
+            bail!("No recovery shares found for selected claim");
+        }
 
         // Decrypt the secret shares using the transport key
         let transport_sk = &user_creds.device_creds.secret_box.transport.sk;

--- a/meta-secret/core/src/node/db/actions/recover.rs
+++ b/meta-secret/core/src/node/db/actions/recover.rs
@@ -135,3 +135,113 @@ impl<Repo: KvLogEventRepo> RecoveryHandler<Repo> {
         Ok(plain_text)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::RecoveryHandler;
+    use crate::meta_tests::fixture_util::fixture::FixtureRegistry;
+    use crate::node::common::model::crypto::aead::EncryptedMessage;
+    use crate::node::common::model::meta_pass::MetaPasswordId;
+    use crate::node::common::model::secret::{SecretDistributionData, SsDistributionId};
+    use crate::node::db::descriptors::shared_secret_descriptor::SsWorkflowDescriptor;
+    use crate::node::db::events::kv_log_event::{KvKey, KvLogEvent};
+    use crate::node::db::events::shared_secret_event::SsWorkflowObject;
+    use crate::node::db::objects::persistent_shared_secret::PersistentSharedSecret;
+    use crate::node::db::repo::generic_db::SaveCommand;
+    use crate::secret::data_block::common::SharedSecretConfig;
+    use crate::secret::shared_secret::{PlainText, SharedSecretEncryption};
+    use anyhow::Result;
+
+    #[tokio::test]
+    async fn recover_works_without_local_distribution_when_recovery_shares_exist() -> Result<()> {
+        let fixture = FixtureRegistry::empty();
+        let user_creds = fixture.state.user_creds.client.clone();
+        let p_obj = fixture.state.p_obj.client.clone();
+        let p_ss = PersistentSharedSecret::from(p_obj.clone());
+        let vault_member = fixture.state.vault_data.client_vault_member.clone();
+
+        let pass_id = MetaPasswordId::build_from_str("recover_without_local_distribution");
+        let claim = vault_member.create_recovery_claim(pass_id.clone());
+        p_ss.save_ss_log_event(claim.clone()).await?;
+
+        let local_distribution_desc = SsWorkflowDescriptor::Distribution(SsDistributionId {
+            pass_id: pass_id.clone(),
+            receiver: user_creds.device_id().clone(),
+        });
+        let local_distribution = p_obj.find_tail_event(local_distribution_desc).await?;
+        assert!(
+            local_distribution.is_none(),
+            "Test precondition: local distribution share must be absent"
+        );
+
+        let cfg = SharedSecretConfig {
+            number_of_shares: 2,
+            threshold: 2,
+        };
+        let shared_secret = SharedSecretEncryption::new(cfg, PlainText::from("2bee|~"))?;
+        let sender_pk = user_creds.device_creds.device.keys.transport_pk();
+        let sender_km = user_creds.device_creds.key_manager()?;
+
+        for (share_index, recovery_id) in claim.recovery_db_ids().into_iter().enumerate() {
+            let share_json = shared_secret.get_share(share_index).as_json()?;
+            let encrypted = sender_km
+                .transport
+                .encrypt_string(PlainText::from(share_json), &sender_pk)?;
+
+            let wf_event = SsWorkflowObject::Recovery(KvLogEvent {
+                key: KvKey::from(SsWorkflowDescriptor::Recovery(recovery_id.clone())),
+                value: SecretDistributionData {
+                    vault_name: user_creds.vault_name.clone(),
+                    claim_id: recovery_id.claim_id,
+                    secret_message: EncryptedMessage::CipherShare { share: encrypted },
+                },
+            });
+
+            p_obj.repo.save(wf_event).await?;
+        }
+
+        let recovery = RecoveryHandler { p_obj };
+        let plain = recovery
+            .recover(user_creds, claim.id, pass_id)
+            .await?;
+
+        assert_eq!(plain.text, "2bee|~");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn recover_fails_when_no_recovery_and_no_local_distribution() -> Result<()> {
+        let fixture = FixtureRegistry::empty();
+        let user_creds = fixture.state.user_creds.client.clone();
+        let p_obj = fixture.state.p_obj.client.clone();
+        let p_ss = PersistentSharedSecret::from(p_obj.clone());
+        let vault_member = fixture.state.vault_data.client_vault_member.clone();
+
+        let pass_id = MetaPasswordId::build_from_str("recover_without_any_shares");
+        let claim = vault_member.create_recovery_claim(pass_id.clone());
+        p_ss.save_ss_log_event(claim.clone()).await?;
+
+        let local_distribution_desc = SsWorkflowDescriptor::Distribution(SsDistributionId {
+            pass_id: pass_id.clone(),
+            receiver: user_creds.device_id().clone(),
+        });
+        let local_distribution = p_obj.find_tail_event(local_distribution_desc).await?;
+        assert!(
+            local_distribution.is_none(),
+            "Test precondition: local distribution share must be absent"
+        );
+
+        let recovery = RecoveryHandler { p_obj };
+        let err = recovery
+            .recover(user_creds, claim.id, pass_id)
+            .await
+            .expect_err("Recover must fail when no shares are available");
+
+        assert!(
+            err.to_string().contains("No recovery shares found for selected claim"),
+            "Unexpected error: {err}"
+        );
+
+        Ok(())
+    }
+}

--- a/meta-secret/core/src/secret/data_block/common.rs
+++ b/meta-secret/core/src/secret/data_block/common.rs
@@ -18,23 +18,21 @@ pub struct SharedSecretConfig {
 
 impl SharedSecretConfig {
     pub fn calculate(num_shares: usize) -> Self {
+        // TODO(security): migrate policy to K = N - 1 after resharing protocol hardening.
+        // Temporary product policy: fixed K=2 for any N>=2.
         match num_shares {
-            1 | 2 => SharedSecretConfig {
-                number_of_shares: num_shares,
+            0 => SharedSecretConfig {
+                number_of_shares: 0,
+                threshold: 0,
+            },
+            1 => SharedSecretConfig {
+                number_of_shares: 1,
                 threshold: 1,
             },
-            n if n % 2 == 0 => {
-                let half = num_shares / 2;
-                SharedSecretConfig {
-                    number_of_shares: num_shares,
-                    threshold: half,
-                }
-            }
             _ => {
-                let quorum = (num_shares / 2) + 1;
                 SharedSecretConfig {
                     number_of_shares: num_shares,
-                    threshold: quorum,
+                    threshold: 2,
                 }
             }
         }
@@ -69,13 +67,17 @@ mod tests {
     use super::*;
     #[test]
     fn test_calculation() {
+        let cfg = SharedSecretConfig::calculate(0);
+        assert_eq!(cfg.number_of_shares, 0);
+        assert_eq!(cfg.threshold, 0);
+
         let cfg = SharedSecretConfig::calculate(1);
         assert_eq!(cfg.number_of_shares, 1);
         assert_eq!(cfg.threshold, 1);
 
         let cfg = SharedSecretConfig::calculate(2);
         assert_eq!(cfg.number_of_shares, 2);
-        assert_eq!(cfg.threshold, 1);
+        assert_eq!(cfg.threshold, 2);
 
         let cfg = SharedSecretConfig::calculate(3);
         assert_eq!(cfg.number_of_shares, 3);
@@ -87,6 +89,6 @@ mod tests {
 
         let cfg = SharedSecretConfig::calculate(5);
         assert_eq!(cfg.number_of_shares, 5);
-        assert_eq!(cfg.threshold, 3);
+        assert_eq!(cfg.threshold, 2);
     }
 }

--- a/meta-secret/mobile/common/src/app_manager.rs
+++ b/meta-secret/mobile/common/src/app_manager.rs
@@ -1,34 +1,33 @@
-use anyhow::{bail};
-use std::sync::Arc;
-use tracing::{info, instrument, Instrument};
+use crate::log_timestamp;
+use anyhow::bail;
 use anyhow::Result;
 use meta_secret_core::crypto::keys::TransportSk;
 use meta_secret_core::node::api::{ReadSyncRequest, SsRecoveryCompletion, SyncRequest};
-use meta_secret_core::node::app::meta_app::messaging::GenericAppStateRequest;
-use meta_secret_core::node::app::meta_app::meta_client_service::{
-    MetaClientDataTransfer, MetaClientService, MetaClientStateProvider,
+use meta_secret_core::node::app::app_manager_shared::{
+    build_client_components, recover_plain_text, resolve_signup_vault_name,
 };
+use meta_secret_core::node::app::meta_app::messaging::GenericAppStateRequest;
+use meta_secret_core::node::app::meta_app::meta_client_service::MetaClientService;
 use meta_secret_core::node::app::sync::api_url::ApiUrl;
 use meta_secret_core::node::app::sync::sync_gateway::SyncGateway;
 use meta_secret_core::node::app::sync::sync_protocol::{HttpSyncProtocol, SyncProtocol};
-use meta_secret_core::node::common::data_transfer::MpscDataTransfer;
 use meta_secret_core::node::common::meta_tracing::client_span;
 use meta_secret_core::node::common::model::device::common::{DeviceName, DeviceType};
 use meta_secret_core::node::common::model::meta_pass::{MetaPasswordId, PlainPassInfo};
-use meta_secret_core::node::common::model::secret::{ClaimId, SecretDistributionType, SsClaim, SsDistributionId, SsDistributionStatus, SsRecoveryId};
-use meta_secret_core::node::common::model::user::common::{UserData, UserDataOutsiderStatus};
+use meta_secret_core::node::common::model::secret::{
+    ClaimId, SecretDistributionType, SsClaim, SsDistributionId, SsDistributionStatus, SsRecoveryId,
+};
+use meta_secret_core::node::common::model::user::common::UserData;
+use meta_secret_core::node::common::model::user::user_creds::UserCreds;
 use meta_secret_core::node::common::model::vault::vault::VaultName;
 use meta_secret_core::node::common::model::{ApplicationState, VaultFullInfo};
-use meta_secret_core::node::db::actions::recover::RecoveryHandler;
 use meta_secret_core::node::db::actions::sign_up::join::JoinActionUpdate;
 use meta_secret_core::node::db::events::vault::vault_log_event::JoinClusterEvent;
-use meta_secret_core::node::db::objects::persistent_object::PersistentObject;
 use meta_secret_core::node::db::repo::generic_db::KvLogEventRepo;
-use meta_secret_core::node::db::repo::persistent_credentials::PersistentCredentials;
 use meta_secret_core::secret::shared_secret::PlainText;
+use std::sync::Arc;
 use std::thread;
-use meta_secret_core::node::common::model::user::user_creds::UserCreds;
-use crate::log_timestamp;
+use tracing::{info, instrument, Instrument};
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum RecoveryStage {
@@ -68,19 +67,22 @@ fn claim_selection_key(
     (is_active, stage, tie_breaker)
 }
 
-pub struct ApplicationManager<Repo: KvLogEventRepo + Send + Sync, SyncP: SyncProtocol + Send + Sync> {
+pub struct ApplicationManager<Repo: KvLogEventRepo + Send + Sync, SyncP: SyncProtocol + Send + Sync>
+{
     pub meta_client_service: Arc<MetaClientService<Repo, SyncP>>,
     pub server: Arc<SyncP>,
     pub sync_gateway: Arc<SyncGateway<Repo, SyncP>>,
     pub master_key: TransportSk,
 }
 
-impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + Sync + 'static> ApplicationManager<Repo, SyncP> {
+impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + Sync + 'static>
+    ApplicationManager<Repo, SyncP>
+{
     pub fn new(
         server: Arc<SyncP>,
         sync_gateway: Arc<SyncGateway<Repo, SyncP>>,
         meta_client_service: Arc<MetaClientService<Repo, SyncP>>,
-        master_key: TransportSk
+        master_key: TransportSk,
     ) -> ApplicationManager<Repo, SyncP> {
         println!("🦀Mobile App Manager: New. Application State Manager");
 
@@ -88,13 +90,13 @@ impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + 
             server,
             sync_gateway,
             meta_client_service,
-            master_key
+            master_key,
         }
     }
 
     pub async fn init(
         client_repo: Arc<Repo>,
-        master_key: TransportSk
+        master_key: TransportSk,
     ) -> Result<ApplicationManager<Repo, HttpSyncProtocol>> {
         println!("🦀Mobile App Manager: Initialize application state manager");
 
@@ -113,29 +115,35 @@ impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + 
 
         Ok(app_manager)
     }
-    
+
     pub fn run_service(&self) -> Result<()> {
         let meta_client_service_clone = self.meta_client_service.clone();
-        
+
         thread::spawn(move || {
             let rt = tokio::runtime::Runtime::new().unwrap();
-            
+
             rt.block_on(async {
                 if let Err(e) = meta_client_service_clone
                     .run()
                     .instrument(client_span())
-                    .await 
+                    .await
                 {
-                    println!("🦀❌ Mobile App Manager: Meta client service error: {:?}", e);
+                    println!(
+                        "🦀❌ Mobile App Manager: Meta client service error: {:?}",
+                        e
+                    );
                 }
             });
         });
-        
+
         Ok(())
     }
 
     pub async fn generate_user_creds(&self, vault_name: VaultName) -> Result<ApplicationState> {
-        println!("🦀 Mobile App Manager: Generate user credentials for vault: {}", vault_name);
+        println!(
+            "🦀 Mobile App Manager: Generate user credentials for vault: {}",
+            vault_name
+        );
         let creds = GenericAppStateRequest::GenerateUserCreds(vault_name);
         let app_state = self.meta_client_service.send_request(creds).await?;
         Ok(app_state)
@@ -144,37 +152,14 @@ impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + 
     #[instrument(skip(self))]
     pub async fn sign_up(&self) -> Result<ApplicationState> {
         info!("Sign Up");
-        
+
         let state = self.get_state().await?;
-        
-        match state {
-            ApplicationState::Local(_) => {
-                bail!("Sign up is not allowed in local state");
-            }
-            ApplicationState::Vault(vault_info) => {
-                let vault_name = match vault_info {
-                    VaultFullInfo::NotExists(user) => user.vault_name,
-                    VaultFullInfo::Outsider(outsider) => match outsider.status {
-                        UserDataOutsiderStatus::NonMember => outsider.user_data.vault_name,
-                        UserDataOutsiderStatus::Pending => {
-                            bail!("Sign up is not allowed in pending state");
-                        }
-                        UserDataOutsiderStatus::Declined => {
-                            bail!("Sign up is not allowed in declined state");
-                        }
-                    },
-                    VaultFullInfo::Member(_) => {
-                        bail!("Sign up is not allowed in vault state");
-                    }
-                };
-                
-                let sign_up = GenericAppStateRequest::SignUp(vault_name);
-                let new_state = self.meta_client_service.send_request(sign_up).await?;
-                println!("🦀 Mobile App Manager: Sign Up. Completed");
-                
-                Ok(new_state)
-            }
-        }
+        let vault_name = resolve_signup_vault_name(&state)?;
+        let sign_up = GenericAppStateRequest::SignUp(vault_name);
+        let new_state = self.meta_client_service.send_request(sign_up).await?;
+        println!("🦀 Mobile App Manager: Sign Up. Completed");
+
+        Ok(new_state)
     }
 
     pub async fn cluster_distribution(&self, plain_pass_info: PlainPassInfo) {
@@ -185,7 +170,10 @@ impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + 
             .unwrap();
     }
 
-    pub async fn find_meta_password_id_by_secret_id(&self, secret_id: &str) -> Result<Option<MetaPasswordId>> {
+    pub async fn find_meta_password_id_by_secret_id(
+        &self,
+        secret_id: &str,
+    ) -> Result<Option<MetaPasswordId>> {
         println!("🦀 Mobile App Manager: Find meta password id by secret id");
         let state = self.get_state().await?;
 
@@ -197,12 +185,18 @@ impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + 
             return Ok(None);
         };
 
-        let found_secret = member.member.vault.secrets
+        let found_secret = member
+            .member
+            .vault
+            .secrets
             .iter()
             .find(|secret| secret.id.text.base64_str() == secret_id)
             .cloned();
 
-        println!("🦀 Mobile App Manager: Looking for secret with id: {}, found: {:?}", secret_id, found_secret);
+        println!(
+            "🦀 Mobile App Manager: Looking for secret with id: {}, found: {:?}",
+            secret_id, found_secret
+        );
 
         Ok(found_secret)
     }
@@ -222,23 +216,19 @@ impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + 
         }
 
         let request = GenericAppStateRequest::GetState;
-        Ok(
-            self.meta_client_service
-            .send_request(request)
-            .await?
-        )
+        Ok(self.meta_client_service.send_request(request).await?)
     }
 
     pub async fn accept_recover_mobile(&self, claim_id: ClaimId) -> Result<()> {
         println!("🦀 Mobile App Manager: Accept recover mobile");
-        
+
         // Force sync before checking claims to ensure we have latest distribution events
         if let Ok(user_creds) = self.meta_client_service.find_user_creds().await {
             println!("🦀 Mobile App Manager: Force sync before accept_recover");
             self.sync_gateway.sync(user_creds.user()).await?;
             println!("🦀 Mobile App Manager: Force sync completed");
         }
-        
+
         let state = self.get_state().await?;
         let ApplicationState::Vault(vault_info) = state else {
             bail!("Not in vault state");
@@ -247,11 +237,13 @@ impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + 
             bail!("Not a member");
         };
 
-        let _ = member.ss_claims.claims
+        let _ = member
+            .ss_claims
+            .claims
             .get(&claim_id)
             .ok_or_else(|| anyhow::anyhow!("Claim not found: {:?}", claim_id))?
             .clone();
-        
+
         self.accept_recover(claim_id).await
     }
 
@@ -273,30 +265,45 @@ impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + 
             bail!("Not a member");
         };
 
-        let _ = member.ss_claims.claims
+        let _ = member
+            .ss_claims
+            .claims
             .get(&claim_id)
             .ok_or_else(|| anyhow::anyhow!("Claim not found: {:?}", claim_id))?
             .clone();
 
-        self.meta_client_service.decline_recover(claim_id.clone()).await?;
+        self.meta_client_service
+            .decline_recover(claim_id.clone())
+            .await?;
         if let Err(e) = self.sync_gateway.sync(user_creds.user()).await {
-            println!("🦀 Mobile App Manager: ⚠️ Sync after decline failed (will retry): {}", e);
+            println!(
+                "🦀 Mobile App Manager: ⚠️ Sync after decline failed (will retry): {}",
+                e
+            );
         }
-        println!("🦀 Mobile App Manager: ✅ Decline recover completed for claim: {:?}", claim_id);
+        println!(
+            "🦀 Mobile App Manager: ✅ Decline recover completed for claim: {:?}",
+            claim_id
+        );
         Ok(())
     }
 
     pub async fn send_decline_completion(&self, claim_id: ClaimId) -> Result<()> {
         println!("🦀 Mobile App Manager: Send decline completion");
         let user_creds = self.meta_client_service.find_user_creds().await?;
-        let state = self.meta_client_service.send_request(GenericAppStateRequest::GetState).await?;
+        let state = self
+            .meta_client_service
+            .send_request(GenericAppStateRequest::GetState)
+            .await?;
         let ApplicationState::Vault(vault_info) = state else {
             bail!("Not in vault state");
         };
         let VaultFullInfo::Member(member) = vault_info else {
             bail!("Not a member");
         };
-        let claim = member.ss_claims.claims
+        let claim = member
+            .ss_claims
+            .claims
             .get(&claim_id)
             .ok_or_else(|| anyhow::anyhow!("Claim not found: {:?}", claim_id))?
             .clone();
@@ -305,7 +312,9 @@ impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + 
             .iter()
             .find(|r| claim.status.get(r) == Some(&SsDistributionStatus::Declined))
             .cloned()
-            .ok_or_else(|| anyhow::anyhow!("No declined receiver found for claim: {:?}", claim_id))?;
+            .ok_or_else(|| {
+                anyhow::anyhow!("No declined receiver found for claim: {:?}", claim_id)
+            })?;
         let vault_name = user_creds.vault_name.clone();
         let pass_id = claim.dist_claim_id.pass_id.clone();
         let recovery_id = SsRecoveryId {
@@ -325,11 +334,13 @@ impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + 
             "🦀 Mobile App Manager: Sending recovery completion for decline, sender: {:?}, receiver: {:?}",
             recovery_id.sender, recovery_id.distribution_id.receiver
         );
-        let sync_request = SyncRequest::Read(Box::from(
-            ReadSyncRequest::SsRecoveryCompletion(completion)
-        ));
+        let sync_request =
+            SyncRequest::Read(Box::from(ReadSyncRequest::SsRecoveryCompletion(completion)));
         if let Err(e) = self.server.send(sync_request).await {
-            println!("🦀 Mobile App Manager: ❌ Failed to send recovery completion: {}", e);
+            println!(
+                "🦀 Mobile App Manager: ❌ Failed to send recovery completion: {}",
+                e
+            );
             return Err(e);
         }
         println!("🦀 Mobile App Manager: ✅ Recovery completion sent successfully");
@@ -364,12 +375,12 @@ impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + 
                 }
                 VaultFullInfo::Member(member) => {
                     let vault_members_count = member.member.vault.members().len();
-                    
+
                     if vault_members_count == 1 {
                         println!("🦀 Mobile App Manager: Single device mode, showing local secret");
                         return self.show_local_secret(user_creds, pass_id).await;
                     }
-                    
+
                     let claim_id = self.find_claim_id_by_pass_id(&pass_id).await;
 
                     match claim_id {
@@ -377,21 +388,21 @@ impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + 
                             bail!("Claim id not found");
                         }
                         Some(claim_id) => {
-                            let recovery_handler = RecoveryHandler {
-                                p_obj: self.sync_gateway.p_obj.clone(),
-                            };
+                            let pass = recover_plain_text(
+                                self.sync_gateway.as_ref(),
+                                user_creds.clone(),
+                                claim_id.clone(),
+                                pass_id.clone(),
+                            )
+                            .await?;
 
-                            let pass = recovery_handler
-                                .recover(user_creds.clone(), claim_id.clone(), pass_id.clone())
-                                .await?;
-                            
                             // Send recovery completion to mark claim as Delivered
                             let ts = log_timestamp::log_timestamp_utc();
                             println!("[{ts}] 🦀 App Manager: Send recovery completion to mark claim as Delivered");
                             if let Some(claim) = member.ss_claims.claims.get(&claim_id) {
                                 let vault_name = user_creds.vault_name.clone();
                                 let device_id = user_creds.device_id();
-                                
+
                                 let recovery_id = SsRecoveryId {
                                     claim_id: claim.dist_claim_id.clone(),
                                     sender: claim.sender.clone(),
@@ -400,24 +411,24 @@ impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + 
                                         receiver: device_id.clone(),
                                     },
                                 };
-                                
+
                                 let completion = SsRecoveryCompletion {
                                     vault_name,
                                     recovery_id,
                                     receiver_status: SsDistributionStatus::Sent,
                                 };
-                                
+
                                 let sync_request = SyncRequest::Read(Box::from(
-                                    ReadSyncRequest::SsRecoveryCompletion(completion)
+                                    ReadSyncRequest::SsRecoveryCompletion(completion),
                                 ));
-                                
+
                                 if let Err(e) = self.server.send(sync_request).await {
                                     println!("🦀 Mobile App Manager: ❌ Failed to send recovery completion: {}", e);
                                 } else {
                                     println!("🦀 Mobile App Manager: ✅ Recovery completion sent successfully");
                                 }
                             }
-                            
+
                             Ok(pass)
                         }
                     }
@@ -425,29 +436,35 @@ impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + 
             },
         }
     }
-    
-    async fn show_local_secret(&self, user_creds: UserCreds, pass_id: MetaPasswordId) -> Result<PlainText> {
+
+    async fn show_local_secret(
+        &self,
+        user_creds: UserCreds,
+        pass_id: MetaPasswordId,
+    ) -> Result<PlainText> {
         use meta_secret_core::node::db::descriptors::shared_secret_descriptor::SsWorkflowDescriptor;
-        use meta_secret_core::secret::shared_secret::UserShareDto;
         use meta_secret_core::recover_from_shares;
-        
+        use meta_secret_core::secret::shared_secret::UserShareDto;
+
         let desc = SsWorkflowDescriptor::Distribution(SsDistributionId {
             pass_id: pass_id.clone(),
             receiver: user_creds.device_id().clone(),
         });
-        
-        let dist = self.sync_gateway.p_obj
+
+        let dist = self
+            .sync_gateway
+            .p_obj
             .find_tail_event(desc)
             .await?
             .ok_or_else(|| anyhow::anyhow!("Distribution not found for single device"))?
             .to_distribution_data()?;
-        
+
         let transport_sk = &user_creds.device_creds.secret_box.transport.sk;
         let decrypted = dist.secret_message.cipher_text().decrypt(transport_sk)?;
         let share = UserShareDto::try_from(&decrypted.msg)?;
-        
+
         let plain_text = recover_from_shares(vec![share])?;
-        
+
         println!("🦀 Mobile App Manager: ✅ Local secret recovered successfully");
         Ok(plain_text)
     }
@@ -465,7 +482,7 @@ impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + 
             Ok(state) => state,
             Err(_) => return None,
         };
-        
+
         let ApplicationState::Vault(VaultFullInfo::Member(member)) = state else {
             return None;
         };
@@ -522,53 +539,24 @@ impl<Repo: KvLogEventRepo + Send + Sync + 'static, SyncP: SyncProtocol + Send + 
         device_type: DeviceType,
     ) -> Result<ApplicationManager<Repo, HttpSyncProtocol>>
     where
-        HttpSyncProtocol: Send + Sync + 'static
+        HttpSyncProtocol: Send + Sync + 'static,
     {
-        let p_obj = {
-            let obj = PersistentObject::new(client_repo.clone());
-            Arc::new(obj)
-        };
-        
-        let creds_repo = PersistentCredentials {
-            p_obj: p_obj.clone(),
-            master_key: master_key.clone(),
-        };
-        let device_creds = {
-            let creds = creds_repo
-                .get_or_generate_device_creds_with_type(device_name, device_type)
-                .await?;
-            Arc::new(creds)
-        };
-
-        let sync_gateway = Arc::new(SyncGateway {
-            id: String::from("client-gateway"),
-            p_obj: p_obj.clone(),
-            sync: sync_protocol.clone(),
-            master_key: master_key.clone()
-        });
-
-        let state_provider = Arc::new(MetaClientStateProvider::new());
-
-        let meta_client_service = {
-            Arc::new(MetaClientService {
-                data_transfer: Arc::new(MetaClientDataTransfer {
-                    dt: MpscDataTransfer::new(),
-                }),
-                sync_gateway: sync_gateway.clone(),
-                state_provider,
-                p_obj: p_obj.clone(),
-                device_data: device_creds.device.clone(),
-                master_key: master_key.clone()
-            })
-        };
+        let (sync_gateway, meta_client_service) = build_client_components(
+            client_repo,
+            sync_protocol.clone(),
+            master_key.clone(),
+            device_name,
+            device_type,
+        )
+        .await?;
 
         let app_manager = ApplicationManager::new(
-            sync_protocol, 
-            sync_gateway, 
-            meta_client_service.clone(), 
-            master_key
+            sync_protocol,
+            sync_gateway,
+            meta_client_service.clone(),
+            master_key,
         );
-        
+
         app_manager.run_service()?;
 
         Ok(app_manager)

--- a/meta-secret/mobile/common/src/mobile_manager.rs
+++ b/meta-secret/mobile/common/src/mobile_manager.rs
@@ -1,5 +1,5 @@
-use std::sync::Arc;
-use tracing::info;
+use crate::app_manager::ApplicationManager;
+use anyhow::{bail, Result};
 use meta_db_sqlite::db::sqlite_migration::EmbeddedMigrationsTool;
 use meta_db_sqlite::db::sqlite_store::SqlIteRepo;
 use meta_secret_core::crypto::keys::TransportSk;
@@ -7,17 +7,17 @@ use meta_secret_core::node::app::sync::sync_protocol::HttpSyncProtocol;
 use meta_secret_core::node::common::model::device::common::{DeviceName, DeviceType};
 use meta_secret_core::node::common::model::meta_pass::{MetaPasswordId, PlainPassInfo};
 use meta_secret_core::node::common::model::secret::{ClaimId, SsClaim};
-use meta_secret_core::node::common::model::{ApplicationState};
-use once_cell::sync::Lazy;
-use std::sync::Mutex;
-use std::future::Future;
-use std::path::PathBuf;
-use anyhow::{bail, Result};
 use meta_secret_core::node::common::model::user::common::UserData;
 use meta_secret_core::node::common::model::vault::vault::VaultName;
+use meta_secret_core::node::common::model::ApplicationState;
 use meta_secret_core::node::db::actions::sign_up::join::JoinActionUpdate;
-use crate::app_manager::ApplicationManager;
+use once_cell::sync::Lazy;
 use std::fs;
+use std::future::Future;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use tracing::info;
 
 static GLOBAL_APP_MANAGER: Lazy<Mutex<Option<Arc<MobileApplicationManager>>>> =
     Lazy::new(|| Mutex::new(None));
@@ -40,7 +40,10 @@ static RUNTIME: Lazy<tokio::runtime::Runtime> = Lazy::new(|| {
 fn resolve_android_package() -> String {
     // Priority 1: Check environment variable
     if let Ok(db_dir) = std::env::var("METASECRET_ANDROID_DB_DIR") {
-        info!("Android package resolved from METASECRET_ANDROID_DB_DIR: {}", db_dir);
+        info!(
+            "Android package resolved from METASECRET_ANDROID_DB_DIR: {}",
+            db_dir
+        );
         return db_dir;
     }
 
@@ -50,7 +53,10 @@ fn resolve_android_package() -> String {
         if let Ok(cmd_str) = String::from_utf8(cmdline) {
             if let Some(package) = cmd_str.split('\0').next() {
                 if !package.is_empty() && package.contains('.') {
-                    info!("Android package resolved from /proc/self/cmdline: {}", package);
+                    info!(
+                        "Android package resolved from /proc/self/cmdline: {}",
+                        package
+                    );
                     return package.to_string();
                 }
             }
@@ -86,8 +92,11 @@ impl MobileApplicationManager {
         let global = GLOBAL_APP_MANAGER.lock().unwrap();
         global.is_some()
     }
-    
-    pub async fn init_ios(master_key: TransportSk, raw_master_key: String) -> anyhow::Result<MobileApplicationManager> {
+
+    pub async fn init_ios(
+        master_key: TransportSk,
+        raw_master_key: String,
+    ) -> anyhow::Result<MobileApplicationManager> {
         Self::init_ios_with_device(
             master_key,
             raw_master_key,
@@ -111,17 +120,14 @@ impl MobileApplicationManager {
             .to_string_lossy()
             .to_string();
         println!("🦀 iOS database path: {}", db_path);
-        
-        Self::init(
-            master_key,
-            &db_path,
-            device_name,
-            device_type,
-        )
-        .await
+
+        Self::init(master_key, &db_path, device_name, device_type).await
     }
-    
-    pub async fn init_android(master_key: TransportSk, raw_master_key: String) -> anyhow::Result<MobileApplicationManager> {
+
+    pub async fn init_android(
+        master_key: TransportSk,
+        raw_master_key: String,
+    ) -> anyhow::Result<MobileApplicationManager> {
         Self::init_android_with_device(
             master_key,
             raw_master_key,
@@ -138,34 +144,30 @@ impl MobileApplicationManager {
         device_type: DeviceType,
     ) -> anyhow::Result<MobileApplicationManager> {
         let package = resolve_android_package();
-        let db_path = format!("/data/data/{}/databases/meta-secret-{}.db", package, raw_master_key);
+        let db_path = format!(
+            "/data/data/{}/databases/meta-secret-{}.db",
+            package, raw_master_key
+        );
         info!("Resolved Android database path: {}", db_path);
-        Self::init(
-            master_key,
-            &db_path,
-            device_name,
-            device_type,
-        )
-        .await
+        Self::init(master_key, &db_path, device_name, device_type).await
     }
 
     pub async fn get_state(&self) -> anyhow::Result<ApplicationState> {
         let app_state = match self.app_manager.get_state().await {
-            Ok(state) => {
-                ApplicationState::from(state)
-            }
+            Ok(state) => ApplicationState::from(state),
             Err(e) => {
                 bail!("Unable to get state from mobile manager: {:?}", e);
             }
         };
         Ok(app_state)
     }
-    
-    pub async fn generate_user_creds(&self, vault_name: VaultName) -> anyhow::Result<ApplicationState> {
+
+    pub async fn generate_user_creds(
+        &self,
+        vault_name: VaultName,
+    ) -> anyhow::Result<ApplicationState> {
         info!("Generate user credentials for vault: {}", vault_name);
-        let app_state = self.app_manager
-            .generate_user_creds(vault_name)
-            .await?;
+        let app_state = self.app_manager.generate_user_creds(vault_name).await?;
         Ok(app_state)
     }
 
@@ -174,12 +176,12 @@ impl MobileApplicationManager {
         Ok(ApplicationState::from(app_state))
     }
 
-    pub async fn update_membership(&self, candidate: UserData, upd: JoinActionUpdate) -> anyhow::Result<()> {
-        Ok(
-            self.app_manager
-                .update_membership(candidate, upd)
-                .await?
-        )
+    pub async fn update_membership(
+        &self,
+        candidate: UserData,
+        upd: JoinActionUpdate,
+    ) -> anyhow::Result<()> {
+        Ok(self.app_manager.update_membership(candidate, upd).await?)
     }
 
     pub async fn cluster_distribution(&self, plain_pass_info: &PlainPassInfo) {
@@ -208,8 +210,10 @@ impl MobileApplicationManager {
 
     pub async fn accept_recover(&self, claim_id: ClaimId) {
         match self.app_manager.accept_recover(claim_id).await {
-            Ok(res) => {res}
-            Err(e) => {panic!("{}", e)}
+            Ok(res) => res,
+            Err(e) => {
+                panic!("{}", e)
+            }
         };
     }
 
@@ -229,7 +233,7 @@ impl MobileApplicationManager {
     pub async fn find_claim_by_pass_id(&self, pass_id: &MetaPasswordId) -> Option<SsClaim> {
         self.app_manager.find_claim_by_pass_id(pass_id).await
     }
-} 
+}
 
 impl MobileApplicationManager {
     async fn init(
@@ -240,7 +244,7 @@ impl MobileApplicationManager {
     ) -> anyhow::Result<MobileApplicationManager> {
         info!("Init mobile state manager");
         info!("Using database path");
-        
+
         match master_key.pk() {
             Ok(_pk) => info!("Master key valid. Public key available"),
             Err(e) => {
@@ -250,10 +254,9 @@ impl MobileApplicationManager {
         }
 
         if let Some(parent_dir) = std::path::Path::new(db_path).parent() {
-            std::fs::create_dir_all(parent_dir)
-                .map_err(|e| {
-                    tracing::error!("Failed to create database directory: {}", e);
-                    anyhow::anyhow!("Failed to create database directory: {}", e)
+            std::fs::create_dir_all(parent_dir).map_err(|e| {
+                tracing::error!("Failed to create database directory: {}", e);
+                anyhow::anyhow!("Failed to create database directory: {}", e)
             })?;
         }
 
@@ -262,7 +265,7 @@ impl MobileApplicationManager {
         let migration_tool = EmbeddedMigrationsTool {
             db_url: conn_url.clone(),
         };
-        
+
         match std::panic::catch_unwind(|| {
             migration_tool.migrate();
         }) {

--- a/meta-secret/tests/src/tests/meta_secret_test.rs
+++ b/meta-secret/tests/src/tests/meta_secret_test.rs
@@ -27,8 +27,8 @@ impl SsClaimVerifierForTestRecovery {
 
 #[cfg(test)]
 pub mod fixture {
-    use meta_secret_core::meta_tests::fixture_util::fixture::states::BaseState;
     use meta_secret_core::meta_tests::fixture_util::fixture::FixtureRegistry;
+    use meta_secret_core::meta_tests::fixture_util::fixture::states::BaseState;
     use meta_secret_core::node::db::in_mem_db::InMemKvLogEventRepo;
     use meta_server_node::server::server_app::ServerApp;
     use std::sync::Arc;
@@ -49,12 +49,12 @@ pub mod fixture {
 
 #[cfg(test)]
 mod test {
-    use crate::fixture::{ExtendedFixtureRegistry, ExtendedFixtureState};
     use super::SsClaimVerifierForTestRecovery;
-    use anyhow::bail;
+    use crate::fixture::{ExtendedFixtureRegistry, ExtendedFixtureState};
     use anyhow::Result;
-    use meta_secret_core::meta_tests::fixture_util::fixture::states::EmptyState;
+    use anyhow::bail;
     use meta_secret_core::meta_tests::fixture_util::fixture::FixtureRegistry;
+    use meta_secret_core::meta_tests::fixture_util::fixture::states::EmptyState;
     use meta_secret_core::meta_tests::spec::test_spec::TestSpec;
     use meta_secret_core::node::app::meta_app::messaging::GenericAppStateRequest;
     use meta_secret_core::node::app::orchestrator::MetaOrchestrator;
@@ -62,14 +62,22 @@ mod test {
     use meta_secret_core::node::common::meta_tracing::{client_span, server_span, vd_span};
     use meta_secret_core::node::common::model::crypto::aead::EncryptedMessage;
     use meta_secret_core::node::common::model::device::common::DeviceName;
-    use meta_secret_core::node::common::model::device::device_creds::{DeviceCreds, DeviceCredsBuilder};
-    use meta_secret_core::node::common::model::meta_pass::{MetaPasswordId, PlainPassInfo, SecurePassInfo};
+    use meta_secret_core::node::common::model::device::device_creds::{
+        DeviceCreds, DeviceCredsBuilder,
+    };
+    use meta_secret_core::node::common::model::meta_pass::{
+        MetaPasswordId, PlainPassInfo, SecurePassInfo,
+    };
     use meta_secret_core::node::common::model::secret::{
         ClaimId, SecretDistributionType, SsClaim, SsDistributionId, SsDistributionStatus,
     };
-    use meta_secret_core::node::common::model::user::common::{UserData, UserDataMember, UserMembership};
+    use meta_secret_core::node::common::model::user::common::{
+        UserData, UserDataMember, UserMembership,
+    };
     use meta_secret_core::node::common::model::user::user_creds::fixture::UserCredentialsFixture;
-    use meta_secret_core::node::common::model::vault::vault::{VaultMember, VaultName, VaultStatus};
+    use meta_secret_core::node::common::model::vault::vault::{
+        VaultMember, VaultName, VaultStatus,
+    };
     use meta_secret_core::node::common::model::vault::vault_data::VaultData;
     use meta_secret_core::node::common::model::{ApplicationState, VaultFullInfo};
     use meta_secret_core::node::db::actions::recover::RecoveryHandler;
@@ -81,14 +89,16 @@ mod test {
     };
     use meta_secret_core::node::db::events::generic_log_event::GenericKvLogEvent;
     use meta_secret_core::node::db::events::shared_secret_event::SsWorkflowObject;
-    use meta_secret_core::node::db::events::vault::vault_log_event::{JoinClusterEvent, VaultActionRequestEvent};
+    use meta_secret_core::node::db::events::vault::vault_log_event::{
+        JoinClusterEvent, VaultActionRequestEvent,
+    };
     use meta_secret_core::node::db::in_mem_db::InMemKvLogEventRepo;
     use meta_secret_core::node::db::objects::persistent_object::PersistentObject;
     use meta_secret_core::node::db::objects::persistent_shared_secret::PersistentSharedSecret;
     use meta_secret_core::recover_from_shares;
     use meta_secret_core::secret::MetaDistributor;
     use meta_secret_core::secret::shared_secret::UserShareDto;
-    use tracing::{info, Instrument};
+    use tracing::{Instrument, info};
 
     struct ServerAppSignUpSpec {
         registry: FixtureRegistry<ExtendedFixtureState>,
@@ -394,10 +404,7 @@ mod test {
         receiver: meta_secret_core::node::common::model::device::common::DeviceId,
         sk: &meta_secret_core::crypto::keys::TransportSk,
     ) -> Result<UserShareDto> {
-        let dist_desc = SsWorkflowDescriptor::Distribution(SsDistributionId {
-            pass_id,
-            receiver,
-        });
+        let dist_desc = SsWorkflowDescriptor::Distribution(SsDistributionId { pass_id, receiver });
         let event = p_obj
             .find_tail_event(dist_desc)
             .await?
@@ -417,7 +424,11 @@ mod test {
     )> {
         let registry = FixtureRegistry::empty();
         let client_user_creds = registry.state.user_creds.client.clone();
-        let client_member = registry.state.vault_data.client_membership.user_data_member();
+        let client_member = registry
+            .state
+            .vault_data
+            .client_membership
+            .user_data_member();
         let single_member_vault = VaultData::from(client_member.clone());
 
         let vault_member = VaultMember {
@@ -543,7 +554,13 @@ mod test {
         spec.vd_gw_sync().await?;
         spec.client_gw_sync().await?;
 
-        let client_state = spec.registry.state.client.client_service.get_app_state().await?;
+        let client_state = spec
+            .registry
+            .state
+            .client
+            .client_service
+            .get_app_state()
+            .await?;
         let ApplicationState::Vault(VaultFullInfo::Member(client_member)) = client_state else {
             bail!("Client has to be vault member");
         };
@@ -581,7 +598,13 @@ mod test {
         client_b_gw.sync(client_b_user.clone()).await?;
         spec.client_gw_sync().await?;
 
-        let client_state = spec.registry.state.client.client_service.get_app_state().await?;
+        let client_state = spec
+            .registry
+            .state
+            .client
+            .client_service
+            .get_app_state()
+            .await?;
         let ApplicationState::Vault(VaultFullInfo::Member(client_member)) = client_state else {
             bail!("Client has to be vault member");
         };
@@ -663,11 +686,10 @@ mod test {
             .p_ss
             .get_ss_log_obj(vault_name.clone())
             .await?;
-        let client_b_ss_log = PersistentSharedSecret::from(
-            spec.registry.state.base.empty.p_obj.client_b.clone(),
-        )
-        .get_ss_log_obj(vault_name.clone())
-        .await?;
+        let client_b_ss_log =
+            PersistentSharedSecret::from(spec.registry.state.base.empty.p_obj.client_b.clone())
+                .get_ss_log_obj(vault_name.clone())
+                .await?;
         let server_ss_log = spec
             .registry
             .state
@@ -715,7 +737,11 @@ mod test {
             prepare_single_device_secret_for_redistribution().await?;
 
         let d2 = registry.state.vault_data.vd_membership.user_data_member();
-        let d3 = registry.state.vault_data.client_b_membership.user_data_member();
+        let d3 = registry
+            .state
+            .vault_data
+            .client_b_membership
+            .user_data_member();
         let (d4, d4_creds) =
             generate_member_for_vault(registry.state.user_creds.client.user().vault_name.clone());
         let (d5, d5_creds) =

--- a/meta-secret/tests/src/tests/meta_secret_test.rs
+++ b/meta-secret/tests/src/tests/meta_secret_test.rs
@@ -2,6 +2,29 @@ use anyhow::Result;
 use meta_secret_core::node::common::model::device::common::DeviceId;
 use meta_secret_core::node::common::model::secret::{SecretDistributionType, SsClaim};
 
+#[allow(dead_code)]
+struct SsClaimVerifierForTestRecovery {
+    sender: DeviceId,
+    receiver: DeviceId,
+}
+
+impl SsClaimVerifierForTestRecovery {
+    #[allow(dead_code)]
+    pub fn verify(&self, claim: SsClaim) -> Result<()> {
+        // Verify the claim properties
+        assert_eq!(claim.sender, self.sender);
+        assert_eq!(claim.distribution_type, SecretDistributionType::Recover);
+        assert_eq!(claim.receivers.len(), 1);
+        assert_eq!(claim.receivers[0], self.receiver);
+
+        // Verify that the recovery database IDs are present
+        let claim_ids = claim.recovery_db_ids();
+        assert_eq!(1, claim_ids.len());
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 pub mod fixture {
     use meta_secret_core::meta_tests::fixture_util::fixture::states::BaseState;
@@ -27,20 +50,27 @@ pub mod fixture {
 #[cfg(test)]
 mod test {
     use crate::fixture::{ExtendedFixtureRegistry, ExtendedFixtureState};
-    use crate::tests::meta_secret_test::SsClaimVerifierForTestRecovery;
+    use super::SsClaimVerifierForTestRecovery;
     use anyhow::bail;
     use anyhow::Result;
     use meta_secret_core::meta_tests::fixture_util::fixture::states::EmptyState;
     use meta_secret_core::meta_tests::fixture_util::fixture::FixtureRegistry;
     use meta_secret_core::meta_tests::spec::test_spec::TestSpec;
     use meta_secret_core::node::app::meta_app::messaging::GenericAppStateRequest;
+    use meta_secret_core::node::app::orchestrator::MetaOrchestrator;
+    use meta_secret_core::node::app::sync::sync_gateway::SyncGateway;
     use meta_secret_core::node::common::meta_tracing::{client_span, server_span, vd_span};
     use meta_secret_core::node::common::model::crypto::aead::EncryptedMessage;
-    use meta_secret_core::node::common::model::meta_pass::{MetaPasswordId, PlainPassInfo};
-    use meta_secret_core::node::common::model::secret::{SsDistributionId, SsDistributionStatus};
-    use meta_secret_core::node::common::model::user::common::UserData;
+    use meta_secret_core::node::common::model::device::common::DeviceName;
+    use meta_secret_core::node::common::model::device::device_creds::{DeviceCreds, DeviceCredsBuilder};
+    use meta_secret_core::node::common::model::meta_pass::{MetaPasswordId, PlainPassInfo, SecurePassInfo};
+    use meta_secret_core::node::common::model::secret::{
+        ClaimId, SecretDistributionType, SsClaim, SsDistributionId, SsDistributionStatus,
+    };
+    use meta_secret_core::node::common::model::user::common::{UserData, UserDataMember, UserMembership};
     use meta_secret_core::node::common::model::user::user_creds::fixture::UserCredentialsFixture;
-    use meta_secret_core::node::common::model::vault::vault::VaultStatus;
+    use meta_secret_core::node::common::model::vault::vault::{VaultMember, VaultName, VaultStatus};
+    use meta_secret_core::node::common::model::vault::vault_data::VaultData;
     use meta_secret_core::node::common::model::{ApplicationState, VaultFullInfo};
     use meta_secret_core::node::db::actions::recover::RecoveryHandler;
     use meta_secret_core::node::db::actions::sign_up::claim::spec::SignUpClaimSpec;
@@ -51,8 +81,13 @@ mod test {
     };
     use meta_secret_core::node::db::events::generic_log_event::GenericKvLogEvent;
     use meta_secret_core::node::db::events::shared_secret_event::SsWorkflowObject;
-    use meta_secret_core::node::db::events::vault::vault_log_event::VaultActionRequestEvent;
+    use meta_secret_core::node::db::events::vault::vault_log_event::{JoinClusterEvent, VaultActionRequestEvent};
+    use meta_secret_core::node::db::in_mem_db::InMemKvLogEventRepo;
+    use meta_secret_core::node::db::objects::persistent_object::PersistentObject;
     use meta_secret_core::node::db::objects::persistent_shared_secret::PersistentSharedSecret;
+    use meta_secret_core::recover_from_shares;
+    use meta_secret_core::secret::MetaDistributor;
+    use meta_secret_core::secret::shared_secret::UserShareDto;
     use tracing::{info, Instrument};
 
     struct ServerAppSignUpSpec {
@@ -353,6 +388,80 @@ mod test {
         }
     }
 
+    async fn read_share_from_node(
+        p_obj: std::sync::Arc<PersistentObject<InMemKvLogEventRepo>>,
+        pass_id: MetaPasswordId,
+        receiver: meta_secret_core::node::common::model::device::common::DeviceId,
+        sk: &meta_secret_core::crypto::keys::TransportSk,
+    ) -> Result<UserShareDto> {
+        let dist_desc = SsWorkflowDescriptor::Distribution(SsDistributionId {
+            pass_id,
+            receiver,
+        });
+        let event = p_obj
+            .find_tail_event(dist_desc)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Distribution event not found"))?;
+        let SsWorkflowObject::Distribution(dist) = event else {
+            bail!("Expected split distribution event");
+        };
+        let decrypted = dist.value.secret_message.cipher_text().decrypt(sk)?;
+        Ok(UserShareDto::try_from(&decrypted.msg)?)
+    }
+
+    async fn prepare_single_device_secret_for_redistribution() -> Result<(
+        FixtureRegistry<EmptyState>,
+        MetaOrchestrator<InMemKvLogEventRepo>,
+        VaultData,
+        MetaPasswordId,
+    )> {
+        let registry = FixtureRegistry::empty();
+        let client_user_creds = registry.state.user_creds.client.clone();
+        let client_member = registry.state.vault_data.client_membership.user_data_member();
+        let single_member_vault = VaultData::from(client_member.clone());
+
+        let vault_member = VaultMember {
+            member: client_member,
+            vault: single_member_vault.clone(),
+        };
+
+        let pass_info = PlainPassInfo::new("late_join_secret".to_string(), "2bee|~".to_string());
+        let secure_pass = SecurePassInfo::from(pass_info);
+        let pass_id = secure_pass.pass_id.clone();
+
+        let distributor = MetaDistributor {
+            p_obj: registry.state.p_obj.client.clone(),
+            user_creds: std::sync::Arc::new(client_user_creds.clone()),
+            vault_member: vault_member.clone(),
+        };
+        distributor
+            .distribute(vault_member.clone(), secure_pass)
+            .await?;
+
+        // In this integration test we do not run server sync, so seed ss_log explicitly.
+        let p_ss = PersistentSharedSecret::from(registry.state.p_obj.client.clone());
+        let seeded_claim = vault_member.create_split_claim(pass_id.clone());
+        p_ss.save_ss_log_event(seeded_claim).await?;
+
+        let orchestrator = MetaOrchestrator {
+            p_obj: registry.state.p_obj.client.clone(),
+            user_creds: client_user_creds,
+        };
+
+        Ok((registry, orchestrator, single_member_vault, pass_id))
+    }
+
+    fn generate_member_for_vault(vault: VaultName) -> (UserDataMember, DeviceCreds) {
+        let extra_creds = DeviceCredsBuilder::generate()
+            .build(DeviceName::generate())
+            .creds;
+        let user = UserData {
+            vault_name: vault,
+            device: extra_creds.device.clone(),
+        };
+        (UserDataMember { user_data: user }, extra_creds)
+    }
+
     #[tokio::test]
     async fn test_sign_up_and_join_two_devices() -> Result<()> {
         let spec = ServerAppSignUpSpec::build().await?;
@@ -367,6 +476,348 @@ mod test {
 
         split.spec.sign_up_and_second_devices_joins().await?;
         split.split().await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_e2e_redistribution_recalculates_shares_after_late_joins() -> Result<()> {
+        let spec = ServerAppSignUpSpec::build().await?;
+        spec.init_server().await?;
+        spec.verify_server_device_creds().await?;
+        spec.client_gw_sync().await?;
+
+        let client_user = spec.user_creds().client.user();
+        let vd_user = spec.user_creds().vd.user();
+        let client_b_user = spec.user_creds().client_b.user();
+
+        let client_b_gw = std::sync::Arc::new(SyncGateway {
+            id: "client_b_gw".to_string(),
+            p_obj: spec.registry.state.base.empty.p_obj.client_b.clone(),
+            sync: spec.registry.state.sync.sync_protocol.clone(),
+            master_key: spec
+                .registry
+                .state
+                .base
+                .empty
+                .device_creds
+                .client_b_master_key
+                .clone(),
+        });
+
+        // D1 creates vault and secret before any joins.
+        SignUpClaimTestAction::sign_up(
+            spec.registry.state.client.p_obj.clone(),
+            &spec.user_creds().client,
+        )
+        .instrument(client_span())
+        .await?;
+        spec.client_gw_sync().await?;
+
+        let pass_id = MetaPasswordId::build_from_str("late_join_secret_k2");
+        let dist_request = GenericAppStateRequest::ClusterDistribution(PlainPassInfo {
+            pass_id: pass_id.clone(),
+            pass: "2bee|~".to_string(),
+        });
+        let app_state = spec
+            .registry
+            .state
+            .client
+            .client_service
+            .build_service_state()
+            .await?
+            .app_state;
+        spec.registry
+            .state
+            .client
+            .client_service
+            .handle_client_request(app_state, dist_request)
+            .await?;
+        spec.client_gw_sync().await?;
+
+        // D2 joins, D1 accepts.
+        spec.vd_gw_sync().await?;
+        SignUpClaimTestAction::sign_up(spec.registry.state.vd.p_obj.clone(), &spec.user_creds().vd)
+            .instrument(vd_span())
+            .await?;
+        spec.vd_gw_sync().await?;
+        spec.client_gw_sync().await?;
+
+        let client_state = spec.registry.state.client.client_service.get_app_state().await?;
+        let ApplicationState::Vault(VaultFullInfo::Member(client_member)) = client_state else {
+            bail!("Client has to be vault member");
+        };
+        let join_d2 = client_member
+            .vault_events
+            .requests
+            .iter()
+            .find_map(|request| match request {
+                VaultActionRequestEvent::JoinCluster(join)
+                    if join.candidate.device.device_id == vd_user.device.device_id =>
+                {
+                    Some(join.clone())
+                }
+                _ => None,
+            })
+            .ok_or_else(|| anyhow::anyhow!("Join request for D2 not found"))?;
+        spec.registry
+            .state
+            .client
+            .orchestrator
+            .update_membership(join_d2, JoinActionUpdate::Accept)
+            .await?;
+        spec.client_gw_sync().await?;
+        spec.vd_gw_sync().await?;
+
+        // D3 joins, D1 accepts.
+        client_b_gw.sync(client_b_user.clone()).await?;
+        client_b_gw.sync(client_b_user.clone()).await?;
+        SignUpClaimTestAction::sign_up(
+            spec.registry.state.base.empty.p_obj.client_b.clone(),
+            &spec.user_creds().client_b,
+        )
+        .await?;
+        client_b_gw.sync(client_b_user.clone()).await?;
+        client_b_gw.sync(client_b_user.clone()).await?;
+        spec.client_gw_sync().await?;
+
+        let client_state = spec.registry.state.client.client_service.get_app_state().await?;
+        let ApplicationState::Vault(VaultFullInfo::Member(client_member)) = client_state else {
+            bail!("Client has to be vault member");
+        };
+        let join_d3 = client_member
+            .vault_events
+            .requests
+            .iter()
+            .find_map(|request| match request {
+                VaultActionRequestEvent::JoinCluster(join)
+                    if join.candidate.device.device_id == client_b_user.device.device_id =>
+                {
+                    Some(join.clone())
+                }
+                _ => None,
+            })
+            .ok_or_else(|| anyhow::anyhow!("Join request for D3 not found"))?;
+        spec.registry
+            .state
+            .client
+            .orchestrator
+            .update_membership(join_d3, JoinActionUpdate::Accept)
+            .await?;
+
+        // Capture recalculated D2/D3 shares right after redistribution (before sender-side sync cleanup).
+        let share_d2 = read_share_from_node(
+            spec.registry.state.client.p_obj.clone(),
+            pass_id.clone(),
+            vd_user.device.device_id.clone(),
+            &spec
+                .user_creds()
+                .client
+                .device_creds
+                .secret_box
+                .transport
+                .sk,
+        )
+        .await?;
+        let share_d3 = read_share_from_node(
+            spec.registry.state.client.p_obj.clone(),
+            pass_id.clone(),
+            client_b_user.device.device_id.clone(),
+            &spec
+                .user_creds()
+                .client
+                .device_creds
+                .secret_box
+                .transport
+                .sk,
+        )
+        .await?;
+
+        // Sync all nodes until convergence.
+        for _ in 0..8 {
+            spec.client_gw_sync().await?;
+            spec.vd_gw_sync().await?;
+            client_b_gw.sync(client_b_user.clone()).await?;
+            client_b_gw.sync(client_b_user.clone()).await?;
+        }
+        for _ in 0..3 {
+            spec.vd_gw_sync().await?;
+            client_b_gw.sync(client_b_user.clone()).await?;
+            client_b_gw.sync(client_b_user.clone()).await?;
+            spec.client_gw_sync().await?;
+        }
+
+        // Consistency: all nodes have split claim with D2+D3 receivers in Delivered state.
+        let vault_name = client_user.vault_name.clone();
+        let client_ss_log = spec
+            .registry
+            .state
+            .client
+            .p_ss
+            .get_ss_log_obj(vault_name.clone())
+            .await?;
+        let vd_ss_log = spec
+            .registry
+            .state
+            .vd
+            .p_ss
+            .get_ss_log_obj(vault_name.clone())
+            .await?;
+        let client_b_ss_log = PersistentSharedSecret::from(
+            spec.registry.state.base.empty.p_obj.client_b.clone(),
+        )
+        .get_ss_log_obj(vault_name.clone())
+        .await?;
+        let server_ss_log = spec
+            .registry
+            .state
+            .server_node
+            .p_ss
+            .get_ss_log_obj(vault_name.clone())
+            .await?;
+
+        let find_split_claim = |claims: &std::collections::HashMap<ClaimId, SsClaim>| {
+            claims
+                .values()
+                .find(|claim| {
+                    claim.distribution_type == SecretDistributionType::Split
+                        && claim.dist_claim_id.pass_id == pass_id
+                        && claim.sender == client_user.device.device_id
+                })
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("Split claim for pass not found"))
+        };
+
+        let claim_client = find_split_claim(&client_ss_log.claims)?;
+        let claim_vd = find_split_claim(&vd_ss_log.claims)?;
+        let claim_client_b = find_split_claim(&client_b_ss_log.claims)?;
+        let claim_server = find_split_claim(&server_ss_log.claims)?;
+
+        for claim in [&claim_client, &claim_vd, &claim_client_b, &claim_server] {
+            assert_eq!(claim.dist_claim_id.pass_id, pass_id);
+            assert_eq!(claim.distribution_type, SecretDistributionType::Split);
+        }
+
+        // K=2 validation: any two redistributed shares recover secret, one share does not.
+        let recovered = recover_from_shares(vec![share_d2.clone(), share_d3.clone()])?;
+        assert_eq!(recovered.text, "2bee|~");
+        assert!(
+            recover_from_shares(vec![share_d2]).is_err(),
+            "One share must be insufficient after K=2 redistribution"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_e2e_redistribution_join_d4_d5_with_fixed_k2() -> Result<()> {
+        let (registry, orchestrator, single_member_vault, pass_id) =
+            prepare_single_device_secret_for_redistribution().await?;
+
+        let d2 = registry.state.vault_data.vd_membership.user_data_member();
+        let d3 = registry.state.vault_data.client_b_membership.user_data_member();
+        let (d4, d4_creds) =
+            generate_member_for_vault(registry.state.user_creds.client.user().vault_name.clone());
+        let (d5, d5_creds) =
+            generate_member_for_vault(registry.state.user_creds.client.user().vault_name.clone());
+
+        let vault_d2 = single_member_vault
+            .clone()
+            .update_membership(UserMembership::Member(d2.clone()))
+            .add_secret(pass_id.clone());
+        orchestrator
+            .redistribute_existing_secrets_for_test(
+                &vault_d2,
+                &JoinClusterEvent {
+                    candidate: d2.user().clone(),
+                },
+            )
+            .await?;
+
+        let vault_d3 = vault_d2
+            .clone()
+            .update_membership(UserMembership::Member(d3.clone()))
+            .add_secret(pass_id.clone());
+        orchestrator
+            .redistribute_existing_secrets_for_test(
+                &vault_d3,
+                &JoinClusterEvent {
+                    candidate: d3.user().clone(),
+                },
+            )
+            .await?;
+
+        let vault_d4 = vault_d3
+            .clone()
+            .update_membership(UserMembership::Member(d4.clone()))
+            .add_secret(pass_id.clone());
+        orchestrator
+            .redistribute_existing_secrets_for_test(
+                &vault_d4,
+                &JoinClusterEvent {
+                    candidate: d4.user().clone(),
+                },
+            )
+            .await?;
+
+        let vault_d5 = vault_d4
+            .clone()
+            .update_membership(UserMembership::Member(d5.clone()))
+            .add_secret(pass_id.clone());
+        orchestrator
+            .redistribute_existing_secrets_for_test(
+                &vault_d5,
+                &JoinClusterEvent {
+                    candidate: d5.user().clone(),
+                },
+            )
+            .await?;
+
+        let d4_event = orchestrator
+            .p_obj
+            .find_tail_event(SsWorkflowDescriptor::Distribution(SsDistributionId {
+                pass_id: pass_id.clone(),
+                receiver: d4.user().device.device_id.clone(),
+            }))
+            .await?;
+        assert!(d4_event.is_some(), "D4 distribution must exist");
+
+        let d5_event = orchestrator
+            .p_obj
+            .find_tail_event(SsWorkflowDescriptor::Distribution(SsDistributionId {
+                pass_id: pass_id.clone(),
+                receiver: d5.user().device.device_id.clone(),
+            }))
+            .await?;
+        assert!(d5_event.is_some(), "D5 distribution must exist");
+
+        let Some(SsWorkflowObject::Distribution(d4_dist)) = d4_event else {
+            panic!("Expected distribution for D4");
+        };
+        let Some(SsWorkflowObject::Distribution(d5_dist)) = d5_event else {
+            panic!("Expected distribution for D5");
+        };
+
+        let d4_plain = d4_dist
+            .value
+            .secret_message
+            .cipher_text()
+            .decrypt(&d4_creds.secret_box.transport.sk)?;
+        let d5_plain = d5_dist
+            .value
+            .secret_message
+            .cipher_text()
+            .decrypt(&d5_creds.secret_box.transport.sk)?;
+
+        let d4_share = UserShareDto::try_from(&d4_plain.msg)?;
+        let d5_share = UserShareDto::try_from(&d5_plain.msg)?;
+
+        let recovered = recover_from_shares(vec![d4_share.clone(), d5_share.clone()])?;
+        assert_eq!(recovered.text, "2bee|~");
+        assert!(
+            recover_from_shares(vec![d4_share]).is_err(),
+            "Single share must not recover secret for fixed K=2"
+        );
 
         Ok(())
     }
@@ -595,29 +1046,6 @@ mod test {
 
         //let app_state_after_recover_json = serde_json::to_string_pretty(&app_state_after_recover)?;
         //println!("{}", app_state_after_recover_json);
-
-        Ok(())
-    }
-}
-
-#[allow(dead_code)]
-struct SsClaimVerifierForTestRecovery {
-    sender: DeviceId,
-    receiver: DeviceId,
-}
-
-impl SsClaimVerifierForTestRecovery {
-    #[allow(dead_code)]
-    pub fn verify(&self, claim: SsClaim) -> Result<()> {
-        // Verify the claim properties
-        assert_eq!(claim.sender, self.sender);
-        assert_eq!(claim.distribution_type, SecretDistributionType::Recover);
-        assert_eq!(claim.receivers.len(), 1);
-        assert_eq!(claim.receivers[0], self.receiver);
-
-        // Verify that the recovery database IDs are present
-        let claim_ids = claim.recovery_db_ids();
-        assert_eq!(1, claim_ids.len());
 
         Ok(())
     }

--- a/meta-secret/wasm/src/app_manager.rs
+++ b/meta-secret/wasm/src/app_manager.rs
@@ -1,31 +1,28 @@
-use anyhow::bail;
+use anyhow::{Result, bail};
 use std::sync::Arc;
-use tracing::{error, info, instrument, Instrument};
+use tracing::{Instrument, error, info, instrument};
 use wasm_bindgen_futures::spawn_local;
 
-use anyhow::Result;
 use meta_secret_core::crypto::keys::TransportSk;
-use meta_secret_core::node::app::meta_app::messaging::GenericAppStateRequest;
-use meta_secret_core::node::app::meta_app::meta_client_service::{
-    MetaClientDataTransfer, MetaClientService, MetaClientStateProvider,
+use meta_secret_core::node::app::app_manager_shared::{
+    build_client_components, find_recovery_claim_id_from_state, recover_plain_text,
+    resolve_signup_vault_name,
 };
+use meta_secret_core::node::app::meta_app::messaging::GenericAppStateRequest;
+use meta_secret_core::node::app::meta_app::meta_client_service::MetaClientService;
 use meta_secret_core::node::app::sync::api_url::ApiUrl;
 use meta_secret_core::node::app::sync::sync_gateway::SyncGateway;
 use meta_secret_core::node::app::sync::sync_protocol::{HttpSyncProtocol, SyncProtocol};
-use meta_secret_core::node::common::data_transfer::MpscDataTransfer;
 use meta_secret_core::node::common::meta_tracing::client_span;
 use meta_secret_core::node::common::model::device::common::{DeviceName, DeviceType};
 use meta_secret_core::node::common::model::meta_pass::{MetaPasswordId, PlainPassInfo};
 use meta_secret_core::node::common::model::secret::ClaimId;
-use meta_secret_core::node::common::model::user::common::{UserData, UserDataOutsiderStatus};
+use meta_secret_core::node::common::model::user::common::UserData;
 use meta_secret_core::node::common::model::vault::vault::VaultName;
 use meta_secret_core::node::common::model::{ApplicationState, VaultFullInfo};
-use meta_secret_core::node::db::actions::recover::RecoveryHandler;
 use meta_secret_core::node::db::actions::sign_up::join::JoinActionUpdate;
 use meta_secret_core::node::db::events::vault::vault_log_event::JoinClusterEvent;
-use meta_secret_core::node::db::objects::persistent_object::PersistentObject;
 use meta_secret_core::node::db::repo::generic_db::KvLogEventRepo;
-use meta_secret_core::node::db::repo::persistent_credentials::PersistentCredentials;
 use meta_secret_core::secret::shared_secret::PlainText;
 
 pub struct ApplicationManager<Repo: KvLogEventRepo, Sync: SyncProtocol> {
@@ -40,7 +37,7 @@ impl<Repo: KvLogEventRepo, Sync: SyncProtocol> ApplicationManager<Repo, Sync> {
         server: Arc<Sync>,
         sync_gateway: Arc<SyncGateway<Repo, Sync>>,
         meta_client_service: Arc<MetaClientService<Repo, Sync>>,
-        master_key: TransportSk
+        master_key: TransportSk,
     ) -> ApplicationManager<Repo, Sync> {
         info!("New. Application State Manager");
 
@@ -48,13 +45,13 @@ impl<Repo: KvLogEventRepo, Sync: SyncProtocol> ApplicationManager<Repo, Sync> {
             server,
             sync_gateway,
             meta_client_service,
-            master_key
+            master_key,
         }
     }
 
     pub async fn init(
         client_repo: Arc<Repo>,
-        master_key: TransportSk
+        master_key: TransportSk,
     ) -> Result<ApplicationManager<Repo, HttpSyncProtocol>> {
         Self::init_with_device(
             client_repo,
@@ -77,16 +74,14 @@ impl<Repo: KvLogEventRepo, Sync: SyncProtocol> ApplicationManager<Repo, Sync> {
             api_url: ApiUrl::prod(),
         });
 
-        let app_manager = Self::client_setup(
+        Self::client_setup(
             client_repo,
-            sync_protocol.clone(),
+            sync_protocol,
             master_key,
             device_name,
             device_type,
         )
-        .await?;
-
-        Ok(app_manager)
+        .await
     }
 
     pub async fn generate_user_creds(&self, vault_name: VaultName) {
@@ -98,32 +93,12 @@ impl<Repo: KvLogEventRepo, Sync: SyncProtocol> ApplicationManager<Repo, Sync> {
     #[instrument(skip(self))]
     pub async fn sign_up(&self) -> Result<ApplicationState> {
         info!("Sign Up");
-        match self.get_state().await {
-            ApplicationState::Local(_) => {
-                bail!("Sign up is not allowed in local state");
-            }
-            ApplicationState::Vault(vault_info) => {
-                let vault_name = match vault_info {
-                    VaultFullInfo::NotExists(user) => user.vault_name,
-                    VaultFullInfo::Outsider(outsider) => match outsider.status {
-                        UserDataOutsiderStatus::NonMember => outsider.user_data.vault_name,
-                        UserDataOutsiderStatus::Pending => {
-                            bail!("Sign up is not allowed in pending state");
-                        }
-                        UserDataOutsiderStatus::Declined => {
-                            bail!("Sign up is not allowed in declined state");
-                        }
-                    },
-                    VaultFullInfo::Member(_) => {
-                        bail!("Sign up is not allowed in vault state");
-                    }
-                };
-                let sign_up = GenericAppStateRequest::SignUp(vault_name);
-                let new_state = self.meta_client_service.send_request(sign_up).await?;
-                info!("Sign Up. Completed");
-                Ok(new_state)
-            }
-        }
+        let state = self.get_state().await;
+        let vault_name = resolve_signup_vault_name(&state)?;
+        let sign_up = GenericAppStateRequest::SignUp(vault_name);
+        let new_state = self.meta_client_service.send_request(sign_up).await?;
+        info!("Sign Up. Completed");
+        Ok(new_state)
     }
 
     pub async fn cluster_distribution(&self, plain_pass_info: PlainPassInfo) {
@@ -180,20 +155,16 @@ impl<Repo: KvLogEventRepo, Sync: SyncProtocol> ApplicationManager<Repo, Sync> {
                 }
                 VaultFullInfo::Member(_) => {
                     let claim_id = self.find_claim_by_pass_id(&pass_id).await;
-
                     match claim_id {
-                        None => {
-                            bail!("Claim id not found");
-                        }
+                        None => bail!("Claim id not found"),
                         Some(claim_id) => {
-                            let recovery_handler = RecoveryHandler {
-                                p_obj: self.sync_gateway.p_obj.clone(),
-                            };
-
-                            let pass = recovery_handler
-                                .recover(user_creds, claim_id, pass_id)
-                                .await?;
-                            Ok(pass)
+                            recover_plain_text(
+                                self.sync_gateway.as_ref(),
+                                user_creds,
+                                claim_id,
+                                pass_id,
+                            )
+                            .await
                         }
                     }
                 }
@@ -206,11 +177,8 @@ impl<Repo: KvLogEventRepo, Sync: SyncProtocol> ApplicationManager<Repo, Sync> {
     }
 
     pub async fn find_claim_by_pass_id(&self, pass_id: &MetaPasswordId) -> Option<ClaimId> {
-        let ApplicationState::Vault(VaultFullInfo::Member(member)) = &self.get_state().await else {
-            return None;
-        };
-
-        member.ss_claims.find_recovery_claim_id(pass_id)
+        let state = self.get_state().await;
+        find_recovery_claim_id_from_state(&state, pass_id)
     }
 
     #[instrument(name = "MetaClientService", skip_all)]
@@ -221,54 +189,25 @@ impl<Repo: KvLogEventRepo, Sync: SyncProtocol> ApplicationManager<Repo, Sync> {
         device_name: DeviceName,
         device_type: DeviceType,
     ) -> Result<ApplicationManager<Repo, HttpSyncProtocol>> {
-        let p_obj = {
-            let obj = PersistentObject::new(client_repo.clone());
-            Arc::new(obj)
-        };
+        let (sync_gateway, meta_client_service) = build_client_components(
+            client_repo,
+            sync_protocol.clone(),
+            master_key.clone(),
+            device_name,
+            device_type,
+        )
+        .await?;
 
-        //Get or generate device credentials
-        let creds_repo = PersistentCredentials {
-            p_obj: p_obj.clone(),
-            master_key: master_key.clone(),
-        };
-        let device_creds = {
-            let creds = creds_repo
-                .get_or_generate_device_creds_with_type(device_name, device_type)
-                .await?;
-            Arc::new(creds)
-        };
-
-        let sync_gateway = Arc::new(SyncGateway {
-            id: String::from("client-gateway"),
-            p_obj: p_obj.clone(),
-            sync: sync_protocol.clone(),
-            master_key: master_key.clone()
-        });
-
-        let state_provider = Arc::new(MetaClientStateProvider::new());
-
-        let meta_client_service = {
-            Arc::new(MetaClientService {
-                data_transfer: Arc::new(MetaClientDataTransfer {
-                    dt: MpscDataTransfer::new(),
-                }),
-                sync_gateway: sync_gateway.clone(),
-                state_provider,
-                p_obj: p_obj.clone(),
-                device_data: device_creds.device.clone(),
-                master_key: master_key.clone()
-            })
-        };
-
-        let app_manager =
-            ApplicationManager::new(sync_protocol, sync_gateway, meta_client_service.clone(), master_key);
+        let app_manager = ApplicationManager::new(
+            sync_protocol,
+            sync_gateway,
+            meta_client_service.clone(),
+            master_key,
+        );
 
         spawn_local(async move {
             if let Err(e) = meta_client_service.run().instrument(client_span()).await {
-                error!(
-                    error = %e,
-                    "Meta client background task failed"
-                );
+                error!(error = %e, "Meta client background task failed");
             }
         });
 


### PR DESCRIPTION
 ## [MS-94] Late-join secret redistribution + K=2 recovery hardening (core/mobile/web)

  ### What’s included
  - Implemented redistribution of already-existing secrets when new devices join.
  - Enforced `K=2` recovery behavior for redistributed secrets (independent of total device count).
  - Updated orchestrator/sync flow to correctly regenerate and deliver redistributed shares.
  - Merged MS-114 changes: device type recognition (`DeviceType`) across Core/CLI/Mobile/WASM/Web.
  - Updated mobile/wasm/web integrations to align with the new redistribution + device-type flow.
  - Fixed client crashes in `showRecovered`:
    - removed `unwrap()` from recovery path when local distribution share is missing;
    - added explicit error: `No recovery shares found for selected claim`.
  - Added corner-case tests for redistribution/recovery behavior.

  ### Why this was needed
  - Previously, secrets created before late joins were not always handled consistently after membership changes.
  - In real client flows, local `Distribution` for the current claim may be absent after redistribution; this caused a panic in mobile/web recovery path.
  - Device type needed to be consistently propagated and persisted to avoid client-side mismatch behavior.

  ### Key changes by module
  - `core/src/node/app/orchestrator.rs`
    Redistribution of existing secrets on join acceptance, idempotency handling, K=2-oriented redistribution logic.
  - `core/src/node/app/sync/sync_gateway.rs`
    Sync flow updates for redistribution workflow.
  - `core/src/secret/data_block/common.rs` and `core/src/node/common/model/vault/vault_data.rs`
    Threshold/config alignment.
  - `core/src/node/db/actions/recover.rs`
    Panic-safe recovery path without mandatory local distribution share + new corner-case tests.
  - `core/src/node/common/model/device/*` and `core/src/node/db/repo/persistent_credentials.rs`
    `DeviceType` model + creds generation/migration/update paths.
  - `mobile/common`, `mobile/uniffi`, `wasm/*`, `web-cli/ui/*`, `meta-cli/*`
    Integration changes for device type and updated recovery/redistribution behavior.

  ### Validation
  - `cargo test -p meta-secret-core recover_ -- --nocapture`
  - `cargo test -p meta-secret-core redistribute_existing_secret -- --nocapture`
  - `cargo test -p meta-secret-tests test_e2e_redistribution_join_d4_d5_with_fixed_k2 -- --nocapture`
  - `RUST_MIN_STACK=33554432 cargo test -p meta-secret-tests test_e2e_redistribution_recalculates_shares_after_late_joins -- --nocapture`
  - `cargo check -p meta-secret-wasm`
  - `cargo check -p mobile-uniffi`

  ### Compatibility / risk
  - Changes touch recovery/sync paths and client initialization.
  - Backward-compatible at data level: existing creds are preserved/migrated with a valid `DeviceType`.
  - Recovery no longer panics when local distribution share is absent; it now either recovers from available shares or returns a controlled error.