### PR TITLE
Set up Cursor Cloud dev environment + document gotchas in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,3 +68,26 @@ IDE entry files in `.Codex/`, `.cursor/`, and `.codex/` bootstrap orchestration 
 | **OpenAI Codex CLI** | Workflow bootstrap | Via `.codex/INDEX.md` + `.codex/ORCHESTRATE.md` |
 
 Rules under [`.ai/rules/`](.ai/rules/) remain the canonical source for policy and stage behavior.
+
+## Cursor Cloud specific instructions
+
+Durable, non-obvious notes for working in the Cursor Cloud VM. Tooling already provisioned in the VM snapshot (no need to reinstall): Rust `1.96.0` (pinned by `rust-toolchain.toml`), the `wasm32-unknown-unknown` target, `wasm-pack`, `bun` (at `~/.bun/bin`), and the `diesel` CLI. `task`/Docker are **not** installed — the `task` targets wrap `docker buildx` for CI parity and do not run here, so iterate locally with `cargo`/`bun` instead.
+
+### Rust workspace (root is `meta-secret/`, not the repo root)
+- **Always pass `--target x86_64-unknown-linux-gnu`** to `cargo build/test/clippy`. `.cargo/config.toml` sets `rustflags = ["-C", "target-feature=+crt-static"]` globally; with no explicit `--target`, cargo applies it to host proc-macros and the build fails with `cannot produce proc-macro ... the target ... does not support these crate types`. An explicit `--target` scopes the rustflags to the target only (this is what the Dockerfile does).
+- Build: `cargo build --target x86_64-unknown-linux-gnu` (run from `meta-secret/`).
+- Test: `cargo test --target x86_64-unknown-linux-gnu`.
+- Lint: `cargo clippy --target x86_64-unknown-linux-gnu` (warnings only on a clean tree).
+
+### meta-server (HTTP sync server, port 3000)
+- The binary requires a **migrated** SQLite DB named `meta-secret.db` in its working directory; `web-server/src/main.rs` does **not** run migrations. Without it the HTTP listener starts but the background sync task panics: `no such table: db_commit_log`.
+- Create the DB once (mirrors `meta-secret/Dockerfile`): from `meta-secret/db/sqlite`, run `DATABASE_URL=<run-dir>/meta-secret.db diesel migration run`.
+- Run: `cargo run -p meta-server --target x86_64-unknown-linux-gnu` from the run dir (auto-creates `master_key.json` + device credentials in `db_commit_log`). Endpoints: `GET /hi`, `POST /meta_request`.
+
+### CLI split/recover (offline core functionality)
+- `meta-secret-cli` reads `config.yaml` (`number_of_shares` / `threshold`) from CWD and writes/reads shares under `secrets/`. `split --secret <s>` creates `secrets/shared-secret-{n}.json` + `.png`; `restore --from json|qr` recovers from any `threshold` shares.
+
+### Web UI (`meta-secret/web-cli/ui`, Vite dev on :5173)
+- Consumes the WASM core via the `file:./pkg` dependency, so build the WASM pkg **before** `bun install`: `cd meta-secret/wasm && wasm-pack build --target web`, then copy per `wasm/Makefile` `local_build` (`cp -r pkg ../web-cli/ui/ && cp pkg.package.json ../web-cli/ui/pkg/package.json`). `pkg/` and `node_modules/` are gitignored and persist in the snapshot.
+- Install/run: `bun install`, then `bun run dev --host`. Lint: `bun run lint:check` (eslint). Note: a newer `bun` rewrites `bun.lock` (adds `configVersion`) — don't commit that incidental change.
+- The app gates the whole UI behind a WebAuthn passkey modal (`PasskeyAuth.vue`, shown whenever not authenticated). In headless/cloud Chrome (no biometrics), enable a DevTools **WebAuthn virtual authenticator** first (Cmd Menu → "Show WebAuthn" → enable virtual authenticator env; ctap2 / internal / resident keys + user verification), then click "Create Passkey". The `/tools/split` and `/tools/recover` pages run fully offline via WASM (split renders QR-code shares; recover uploads QR images).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified the full development environment for this Rust workspace in the Cursor Cloud VM, and documented the non-obvious setup gotchas in `AGENTS.md` under a new `## Cursor Cloud specific instructions` section. No application/source code was changed (only `AGENTS.md`).

Verified end-to-end across all the main services:

| Service | Build | Lint | Test | Run |
|---|---|---|---|---|
| Rust workspace (`meta-secret/`) | `cargo build --target x86_64-unknown-linux-gnu` | `cargo clippy --target x86_64-unknown-linux-gnu` | `cargo test --target x86_64-unknown-linux-gnu` (162 core + others, 0 failures) | — |
| meta-server (HTTP :3000) | (above) | — | — | `cargo run -p meta-server` after `diesel migration run` |
| CLI (`meta-secret-cli`) | (above) | — | — | `split` / `restore` roundtrip |
| Web UI (`web-cli/ui`) | `wasm-pack build` + `bun install` | `bun run lint:check` | — | `bun run dev --host` (Vite :5173) |

## Key findings (now in AGENTS.md)

- **`--target x86_64-unknown-linux-gnu` is mandatory** for all `cargo` commands: `.cargo/config.toml` sets `+crt-static` globally, which breaks host proc-macro builds unless an explicit `--target` scopes the rustflags (this is what the Dockerfile does).
- `task`/Docker are not available in the cloud VM (they wrap `docker buildx` for CI parity); iterate locally with `cargo`/`bun`.
- **meta-server needs a migrated `meta-secret.db`** in its working dir (`main.rs` doesn't migrate); create it via `diesel migration run`, else the background task panics with `no such table: db_commit_log`.
- Web UI consumes WASM via `file:./pkg`, so build the pkg before `bun install`; the app gates everything behind a WebAuthn passkey modal — use a DevTools virtual authenticator in headless Chrome.

## Hello-world demonstrations

CLI split → recover roundtrip (recovered `topSecretPassword42!` from only 2 of 3 shares) and meta-server HTTP + SQLite-backed init:
[cli_and_server_evidence.log](https://cursor.com/agents/bc-10217745-c8f4-4d55-b582-c0479963a78d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcli_and_server_evidence.log)

Web UI: passkey auth via DevTools virtual authenticator, then splitting a secret into QR-code shares (in-browser WASM core):
[web_passkey_auth_and_split_demo.mp4](https://cursor.com/agents/bc-10217745-c8f4-4d55-b582-c0479963a78d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_passkey_auth_and_split_demo.mp4)
[Three QR-code shares generated by the web split tool](https://cursor.com/agents/bc-10217745-c8f4-4d55-b582-c0479963a78d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fweb_split_qr_shares.webp)

## Update script

`cargo fetch --manifest-path meta-secret/Cargo.toml` (minimal Rust dependency refresh on VM startup). Tool installs (`wasm-pack`, `bun`, `diesel`, `wasm32` target) persist in the VM snapshot; build/run steps are documented in AGENTS.md rather than the startup script.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-10217745-c8f4-4d55-b582-c0479963a78d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-10217745-c8f4-4d55-b582-c0479963a78d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

